### PR TITLE
global: uniform licence headers in source files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,10 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 [run]
 source = dictdiffer

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2013 Fatih Erikli.
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 *.egg
 *.egg-info
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 language: python
 
 python:

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,16 @@
+Authors
+-------
+
+Dictdiffer was originally developed by Fatih Erikli.  It is now being
+developed and maintained by the Invenio collaboration.  You can
+contact us at `info@invenio-software.org
+<mailto:info@invenio-software.org>`_
+
+Contributors
+^^^^^^^^^^^^
+* Fatih Erikli <fatiherikli@gmail.com>
+* Brian Rue <brianrue@gmail.com>
+* Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+* Tibor Simko <tibor.simko@cern.ch>
+* Jiri Kuncar <jiri.kuncar@cern.ch>
+* Jason Peddle <jwpeddle@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,28 @@
-Copyright (c) 2013 Fatih Erikli
+Dictdiffer is free software; you can redistribute it and/or modify it
+under the terms of the MIT License quoted below.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (C) 2013 Fatih Erikli.
+Copyright (C) 2013, 2014 CERN.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+In applying this license, CERN does not waive the privileges and
+immunities granted to it by virtue of its status as an
+Intergovernmental Organization or submit itself to any jurisdiction.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,12 @@
 # This file is part of Dictdiffer.
+#
 # Copyright (C) 2014 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
-# it under the terms of the MIT/X11 License; see LICENSE file for more
+# it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-include README.rst CHANGES LICENSE MANIFEST.in
+include README.rst CHANGES AUTHORS LICENSE MANIFEST.in
 include .coveragerc pytest.ini
 include docs/*.rst docs/*.py docs/Makefile
 include *.py *.sh

--- a/dictdiffer.py
+++ b/dictdiffer.py
@@ -1,3 +1,12 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2013 Fatih Erikli.
+# Copyright (C) 2013, 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 """Dictdiffer is a helper module to diff and patch dictionaries."""
 
 import sys

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,11 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 # Makefile for Sphinx documentation
 #
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
 #
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+#
 # Dictdiffer documentation build configuration file, created by
 # sphinx-quickstart on Tue Aug 26 12:50:15 2014.
 #

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,10 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 [pytest]
 addopts = --clearcache --pep8 --doctest-modules --cov=dictdiffer.py tests.py dictdiffer.py

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+#
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2013 Fatih Erikli.
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 pep257 dictdiffer.py
 sphinx-build -qnNW docs docs/_build/html
 python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,12 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2013 Fatih Erikli.
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,12 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2013 Fatih Erikli.
+# Copyright (C) 2013, 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 import unittest
 
 from dictdiffer import diff, patch, revert, swap, dot_lookup

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,11 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2014 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
 [tox]
 envlist = py26, py27, py33, py34
 


### PR DESCRIPTION
- Adds header containing licence information to each source file.
- Amends copyright holders and copyright years for every source file
  based on its git commit log history.
- Adds `AUTHORS` file.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
