### PR TITLE
tests: py.test removal from install requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ python:
 install:
   - pip install --upgrade pip  --use-mirrors
   - pip install coveralls pep257 --use-mirrors
+  - pip install pytest pytest-pep8 pytest-cov pytest-cache --use-mirrors
   - pip install -e .[docs]
 
 script:

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,4 @@
 # details.
 
 [pytest]
-addopts = --clearcache --pep8 --doctest-modules --cov=dictdiffer.py tests.py dictdiffer.py
+addopts = --clearcache --pep8 --ignore=docs --doctest-modules --cov=dictdiffer --cov-report=term-missing tests.py dictdiffer.py

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,11 @@ class PyTest(TestCommand):
 
 
 tests_require = [
-    'pytest', 'pytest-cache', 'pytest-cov', 'pytest-pep8', 'coverage'
+    'pytest-cache>=1.0',
+    'pytest-cov>=1.8.0',
+    'pytest-pep8>=1.0.6',
+    'pytest>=2.6.1',
+    'coverage'
 ]
 
 setup(
@@ -52,9 +56,8 @@ setup(
     url='https://github.com/inveniosoftware/dictdiffer',
     py_modules=['dictdiffer'],
     extras_require={
-        "docs": ["sphinx_rtd_theme"] + tests_require,
+        "docs": ["sphinx_rtd_theme"],
     },
-    install_requires=tests_require,
     tests_require=tests_require,
     cmdclass={'test': PyTest},
     classifiers=[


### PR DESCRIPTION
After seeing the discussion at https://bitbucket.org/pypa/setuptools/issue/196/tests_require-pytest-pytest-cov-breaks I tried to specify the versions for packages with the dash `-` in `tests_require`.
