### PR TITLE
diff: richer docstring on new `ignore` parameter

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -38,6 +38,9 @@ def diff(first, second, node=None, ignore=None):
     :param second: new dictionary or list
     :param node: key for comparison that can be used in :func:`dot_lookup`
     :param ignore: list of keys that should not be checked
+
+    .. versionchanged:: 0.3
+       Added *ignore* parameter.
     """
     node = node or []
     if all(map(lambda x: isinstance(x, string_types), node)):


### PR DESCRIPTION
- Enhances docstring of `diff()` in order to document exact version
  number when the `ignore` parameter was added.  (see #34) (see PR #35)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
