### PR TITLE
diff: fix for unicode keys

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -1,7 +1,7 @@
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2013 Fatih Erikli.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -16,8 +16,12 @@ from .version import __version__
 
 if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
     string_types = str,
+    text_type = str
+    PY2 = False
 else:  # pragma: no cover (Python 2/3 specific code)
     string_types = basestring,
+    text_type = unicode
+    PY2 = True
 
 (ADD, REMOVE, CHANGE) = (
     'add', 'remove', 'change')
@@ -54,9 +58,13 @@ def diff(first, second, node=None, ignore=None):
         # dictionaries are not hashable, we can't use sets
         def check(key):
             """Test if key in current node should be ignored."""
+            if PY2 and isinstance(key, text_type):
+                new_key = key.encode('utf-8')
+            else:
+                new_key = key
             return ignore is None \
-                or (dotted_node + [key] if isinstance(dotted_node, list)
-                    else '.'.join(node + [str(key)])) not in ignore
+                or (node + [key] if isinstance(dotted_node, list)
+                    else '.'.join(node + [str(new_key)])) not in ignore
 
         intersection = [k for k in first if k in second and check(k)]
         addition = [k for k in second if k not in first and check(k)]

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -12,6 +12,8 @@
 import sys
 import copy
 
+from .version import __version__
+
 if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
     string_types = str,
 else:  # pragma: no cover (Python 2/3 specific code)
@@ -19,8 +21,6 @@ else:  # pragma: no cover (Python 2/3 specific code)
 
 (ADD, REMOVE, CHANGE) = (
     'add', 'remove', 'change')
-
-from .version import __version__
 
 __all__ = ('diff', 'patch', 'swap', 'revert', 'dot_lookup', '__version__')
 

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2013 Fatih Erikli.
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -93,6 +95,16 @@ class DictDifferTests(unittest.TestCase):
         second = {'a': 'a'}
         diffed = next(diff(first, second))
         assert ('change', 'a', (['a'], 'a')) == diffed
+
+    def test_unicode_keys(self):
+        first = {u'привет': 1}
+        second = {'hello': 1}
+        diffed = list(diff(first, second))
+        assert ('add', '', [('hello', 1)]) in diffed
+        assert ('remove', '', [(u'привет', 1)]) in diffed
+
+        diffed = list(diff(first, second, ignore=['hello']))
+        assert ('remove', '', [(u'привет', 1)]) == diffed[0]
 
     def test_ignore_key(self):
         first = {'a': 'a', 'b': 'b', 'c': 'c'}


### PR DESCRIPTION
* Fixes exception when dict has unicode keys and ignore parameter is provided.  (closes #50)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>