### PR TITLE
dictdiffer: pragmatic merge

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Contributors:
 * Tibor Simko <tibor.simko@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Jason Peddle <jwpeddle@gmail.com>
+* Martin Vesper <martin.vesper@cern.ch>

--- a/dictdiffer/_compat.py
+++ b/dictdiffer/_compat.py
@@ -15,7 +15,13 @@ if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
     string_types = str,
     text_type = str
     PY2 = False
+
+    from itertools import zip_longest as _zip_longest
+    izip_longest = _zip_longest
 else:  # pragma: no cover (Python 2/3 specific code)
     string_types = basestring,
     text_type = unicode
     PY2 = True
+
+    from itertools import izip_longest as _zip_longest
+    izip_longest = _zip_longest

--- a/dictdiffer/_compat.py
+++ b/dictdiffer/_compat.py
@@ -1,0 +1,21 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Python compatibility definitions."""
+
+import sys
+
+
+if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
+    string_types = str,
+    text_type = str
+    PY2 = False
+else:  # pragma: no cover (Python 2/3 specific code)
+    string_types = basestring,
+    text_type = unicode
+    PY2 = True

--- a/dictdiffer/conflict.py
+++ b/dictdiffer/conflict.py
@@ -1,0 +1,82 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sub module to recognize conflicts in dictdiffer patches."""
+
+import itertools
+
+from .utils import get_path, is_super_path
+
+
+class Conflict(object):
+
+    """Wrapper class to store and handle two conflicting patches."""
+
+    def __init__(self, patch1, patch2):
+        """Initialize Conflict object.
+
+        :param patch1: First patch tuple
+        :param patch2: Second patch tuple
+        """
+        self.first_patch = patch1
+        self.second_patch = patch2
+        self.take = None
+        self.handled = False
+
+    def take_patch(self):
+        """Return the patch determined by the *take* attribute."""
+        if self.take:
+            return self.first_patch if self.take == 'f' else self.second_patch
+        raise Exception('Take attribute not set.')
+
+    def __repr__(self):
+        """Return string representation."""
+        return 'Conflict({0}, {1})'.format(self.first_patch, self.second_patch)
+
+
+class ConflictFinder(object):
+
+    """Responsible for finding conflicting patches."""
+
+    def _is_conflict(self, patch1, patch2):
+        """Decide on a conflict between two patches.
+
+        The conditions are:
+        1. The paths are identical
+        2. On of the paths is the super path of the other
+
+        :param patch1: First patch tuple
+        :param patch2: First patch tuple
+        """
+        path1 = get_path(patch1)
+        path2 = get_path(patch2)
+
+        if path1 == path2:
+            return True
+        elif is_super_path(path1, path2) and patch1[0] == 'remove':
+            return True
+        elif is_super_path(path2, path1) and patch2[0] == 'remove':
+            return True
+
+        return False
+
+    def find_conflicts(self, first_patches, second_patches):
+        """Find all conflicts between two lists of patches.
+
+        Iterates over the lists of patches, comparing each patch from list
+        one to each patch from list two.
+
+        :param first_patches: List of patch tuples
+        :param second_patches: List of patch tuples
+        """
+        self.conflicts = [Conflict(patch1, patch2) for patch1, patch2
+                          in itertools.product(first_patches,
+                                               second_patches)
+                          if self._is_conflict(patch1, patch2)]
+
+        return self.conflicts

--- a/dictdiffer/merge.py
+++ b/dictdiffer/merge.py
@@ -1,0 +1,144 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sub module to handle the merging of dictdiffer patches."""
+
+from . import diff
+from .conflict import ConflictFinder
+from .unify import Unifier
+from .resolve import Resolver, UnresolvedConflictsException
+from .utils import PathLimit
+
+
+class Merger(object):
+
+    """Class wrapping steps of the automated merging process.
+
+    Usage:
+        >>> lca = {}
+        >>> first = {'foo': 'bar'}
+        >>> second = {'bar': 'foo'}
+        >>> path_limits = []
+        >>> actions = {}
+        >>> additional_info = {}
+        >>> m = Merger(lca, first, second, actions,
+        ...            path_limits, additional_info)
+        >>> try:
+        ...     m.run()
+        ... except UnresolvedConflictsException:
+        ...     # fix the conflicts
+        ...     m.continue_run()
+    """
+
+    def __init__(self,
+                 lca, first, second, actions,
+                 path_limits=[], additional_info=None):
+        """Initialization of Merger object.
+
+        :param lca: latest common ancestor of the two diverging data structures
+        :param first: first data structure
+        :param second: second data structure
+        :param path_limits: list of paths, utilized to instantiate a
+                            dictdiffer.utils.PathLimit object
+        :param additional_info: Any object containing additional information
+                                used by the resolution functions
+        """
+        self.lca = lca
+        self.first = first
+        self.second = second
+        self.path_limit = PathLimit(path_limits)
+
+        self.actions = actions
+        self.additional_info = additional_info
+
+        self.conflict_finder = ConflictFinder()
+
+        self.resolver = Resolver(self.actions,
+                                 self.additional_info)
+
+        self.unifier = Unifier()
+
+        self.conflicts = []
+        self.unresolved_conflicts = []
+
+    def run(self):
+        """Run the automated merging process.
+
+        Runs every step necessary for the automated merging process, raising
+        an UnresolvedConflictsException in case that the provided resolution
+        actions can not solve a given conflict.
+
+        After every performed step, the results are stored inside attributes of
+        the merger object.
+        """
+        self.extract_patches()
+        self.find_conflicts()
+        self.resolve_conflicts()
+
+        if self.unresolved_conflicts:
+            raise UnresolvedConflictsException(self.unresolved_conflicts)
+
+        self.unify_patches()
+
+    def continue_run(self, picks):
+        """Continue the merge after an UnresolvedConflictsException.
+
+        :param picks: a list of 'f' or 's' strings, which utilize the Conflicts
+                      class *take* attribute
+        """
+        self.resolver.manual_resolve_conflicts(picks)
+        self.unresolved_conflicts = []
+        self.unify_patches()
+
+    def extract_patches(self):
+        """Extract the patches.
+
+        Extracts the differences between the *lca* and the *first* and
+        *second* data structure and stores them in the attributes
+        *first_patches* and *second_patches*.
+        """
+        self.first_patches = list(diff(self.lca, self.first,
+                                       path_limit=self.path_limit,
+                                       expand=True))
+        self.second_patches = list(diff(self.lca, self.second,
+                                        path_limit=self.path_limit,
+                                        expand=True))
+
+    def find_conflicts(self):
+        """Find conflicts between the tow lists of patches.
+
+        Finds the conflicts between the two difference lists and stores
+        them in the *conflicts* attribute.
+        """
+        self.conflicts = (self
+                          .conflict_finder
+                          .find_conflicts(self.first_patches,
+                                          self.second_patches))
+
+    def resolve_conflicts(self):
+        """Resolve the conflicts.
+
+        Runs the automated conflict resolution process.
+        Occurring unresolvable conflicts are stored in *unresolved_conflicts*.
+        """
+        try:
+            self.resolver.resolve_conflicts(self.first_patches,
+                                            self.second_patches,
+                                            self.conflicts)
+        except UnresolvedConflictsException as e:
+            self.unresolved_conflicts = e.content
+
+    def unify_patches(self):
+        """Unify the patches after the conflict resolution.
+
+        Unifies the patches after a successful merge and stores them in
+        *unified_patches*.
+        """
+        self.unified_patches = self.unifier.unify(self.first_patches,
+                                                  self.second_patches,
+                                                  self.conflicts)

--- a/dictdiffer/resolve.py
+++ b/dictdiffer/resolve.py
@@ -1,0 +1,154 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sub module to handle the conflict resolution."""
+
+from .utils import get_path
+
+
+class UnresolvedConflictsException(Exception):
+
+    """Exception raised in case of an unresolveable conflict.
+
+    Exception raised in case of conflicts, that can not be resolved using
+    the provided actions in the automated merging process.
+    """
+
+    def __init__(self, unresolved_conflicts):
+        """Initialization of UnresolvedConflictsException.
+
+        :param unresolved_conflicts: list of unresolved conflicts.
+                                     dictdiffer.conflict.Conflict objects.
+        """
+        self.message = ("The unresolved conflicts are stored in the *content* "
+                        "attribute of this exception or in the "
+                        "*unresolved_conflicts* attribute of the "
+                        "dictdiffer.merge.Merger object.")
+        self.content = unresolved_conflicts
+
+    def __repr__(self):
+        """String representation."""
+        return self.message
+
+    def __str__(self):
+        """String representation."""
+        return self.message
+
+
+class NoFurtherResolutionException(Exception):
+
+    """Exception raised to stop the automated resolution process.
+
+    Raised in case that the automatic conflict resolution process should stop
+    trying more general keys.
+    """
+
+    pass
+
+
+class Resolver(object):
+
+    """Class handling the conflict resolution process.
+
+    Presents the given conflicts to actions designed to solve them.
+    """
+
+    def __init__(self, actions, additional_info=None):
+        """Initialization of the Resolver.
+
+        :param action: dict object containing the necessary resolution
+                       functions
+        :param additional_info: any additional information required by the
+                                actions
+        """
+        self.actions = actions
+        self.additional_info = additional_info
+
+        self.unresolved_conflicts = []
+
+    def _auto_resolve(self, conflict):
+        """Try to auto resolve conflicts.
+
+        Method trying to auto resolve conflicts in case that the perform the
+        same amendment.
+        """
+        if conflict.first_patch == conflict.second_patch:
+            conflict.take = 'f'
+            return True
+        return False
+
+    def _find_conflicting_path(self, conflict):
+        """Return the shortest path commown to two patches."""
+        p1p = get_path(conflict.first_patch)
+        p2p = get_path(conflict.second_patch)
+
+        # This returns the shortest path
+        return p1p if len(p1p) <= len(p2p) else p2p
+
+    def _consecutive_slices(self, iterable):
+        """Build a list of consecutive slices of a given path.
+
+        >>> r = Resolver(None, None)
+        >>> list(r._consecutive_slices([1, 2, 3]))
+        [[1, 2, 3], [1, 2], [1]]
+        """
+        return (iterable[:i] for i in reversed(range(1, len(iterable)+1)))
+
+    def resolve_conflicts(self, first_patches, second_patches, conflicts):
+        """Method to present the given conflicts to the actions.
+
+        The method, will map the conflicts to an actions based on the path of
+        the conflict. In case that the resolution attempt is not successful, it
+        will strip the last element of the path and try again, until the
+        resolution is just not possible.
+
+        :param first_patches: list of dictdiffer.diff patches
+        :param second_patches: list of dictdiffer.diff patches
+        :param conflicts: list of Conflict objects
+        """
+        for conflict in conflicts:
+            conflict_path = self._find_conflicting_path(conflict)
+
+            if self._auto_resolve(conflict):
+                continue
+            # Let's do some cascading here
+            for sub_path in self._consecutive_slices(conflict_path):
+                try:
+                    if self.actions[sub_path](conflict,
+                                              first_patches,
+                                              second_patches,
+                                              self.additional_info):
+                        break
+                except NoFurtherResolutionException:
+                    self.unresolved_conflicts.append(conflict)
+                    break
+                except KeyError:
+                    pass
+            else:
+                # The conflict could not be resolved
+                self.unresolved_conflicts.append(conflict)
+
+        if self.unresolved_conflicts:
+            raise UnresolvedConflictsException(self.unresolved_conflicts)
+
+    def manual_resolve_conflicts(self, picks):
+        """Method to manually resolve conflicts.
+
+        This method resolves conflicts that could not be resolved in an
+        automatic way. The picks parameter utilized the *take* attribute of the
+        Conflict objects.
+
+        :param picks: list of 'f' or 's' strings, utilizing the *take*
+                      parameter of each Conflict object
+        """
+        if len(picks) != len(self.unresolved_conflicts):
+            raise UnresolvedConflictsException(self.unresolved_conflicts)
+        for pick, conflict in zip(picks, self.unresolved_conflicts):
+            conflict.take = pick
+
+        self.unresolved_conflicts = []

--- a/dictdiffer/unify.py
+++ b/dictdiffer/unify.py
@@ -1,0 +1,53 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sub module to handle the unification of patches after the merge."""
+
+from .utils import get_path, nested_hash
+
+
+class Unifier(object):
+
+    """Class handling the unification process after the merge."""
+
+    def unify(self, first_patches, second_patches, conflicts):
+        """Unify two lists of patches into one.
+
+        Takes into account their appearance in the given list of conflicts.
+
+        :param first_patches: list of dictdiffer.diff patches
+        :param second_patches: list of dictdiffer.diff patches
+        :param conflicts: list of Conflict objects
+        """
+        self.unified_patches = []
+        sorted_patches = sorted(first_patches + second_patches, key=get_path)
+
+        self._build_index(conflicts)
+
+        for patch in sorted_patches:
+            conflict = self._index.get(nested_hash(patch))
+
+            if conflict:
+                if not conflict.handled:
+                    conflict.handled = True
+                    self.unified_patches.append(conflict.take_patch())
+            else:
+                self.unified_patches.append(patch)
+
+        return self.unified_patches
+
+    def _build_index(self, conflicts):
+        """Create a dictionary attribute mapping patches to conflicts.
+
+        Creates a dictionary attribute mapping the tuplefied version of each
+        patch to it's containing Conflict object.
+        """
+        self._index = {}
+        for conflict in conflicts:
+            self._index[nested_hash(conflict.first_patch)] = conflict
+            self._index[nested_hash(conflict.second_patch)] = conflict

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -1,0 +1,100 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Utils gathers helper functions, classes for the dictdiffer module."""
+
+from ._compat import string_types
+
+
+class PathLimit(object):
+
+    """Class to limit recursion depth during the dictdiffer.diff execution."""
+
+    def __init__(self, path_limits=[], final_key=None):
+        """Initialize a dictionary structure to determine a path limit.
+
+        :param path_limits: list of keys (tuples) determining the path limits
+        :param final_key: the key used in the dictionary to determin if the
+                          path is final
+
+            >>> pl = PathLimit( [('foo', 'bar')] , final_key='!@#$%FINAL')
+            >>> pl.dict
+            {'foo': {'bar': {'!@#$%FINAL': True}}}
+        """
+        self.final_key = final_key if final_key else '!@#$FINAL'
+        self.dict = {}
+        for key_path in path_limits:
+            containing = self.dict
+            for key in key_path:
+                try:
+                    containing = containing[key]
+                except KeyError:
+                    containing[key] = {}
+                    containing = containing[key]
+
+            containing[self.final_key] = True
+
+    def path_is_limit(self, key_path):
+        """Querie the PathLimit object if the given key_path is a limit.
+
+        >>> pl = PathLimit( [('foo', 'bar')] , final_key='!@#$%FINAL')
+        >>> pl.path_is_limit( ('foo', 'bar') )
+        True
+        """
+        containing = self.dict
+        for key in key_path:
+            try:
+                containing = containing[key]
+            except KeyError:
+                try:
+                    containing = containing['*']
+                except KeyError:
+                    return False
+
+        return containing.get(self.final_key, False)
+
+
+def dot_lookup(source, lookup, parent=False):
+    """Allow you to reach dictionary items with string or list lookup.
+
+    Recursively find value by lookup key split by '.'.
+
+        >>> dot_lookup({'a': {'b': 'hello'}}, 'a.b')
+        'hello'
+
+    If parent argument is True, returns the parent node of matched
+    object.
+
+        >>> dot_lookup({'a': {'b': 'hello'}}, 'a.b', parent=True)
+        {'b': 'hello'}
+
+    If node is empty value, returns the whole dictionary object.
+
+        >>> dot_lookup({'a': {'b': 'hello'}}, '')
+        {'a': {'b': 'hello'}}
+
+    """
+    if lookup is None or lookup == '' or lookup == []:
+        return source
+
+    value = source
+    if isinstance(lookup, string_types):
+        keys = lookup.split('.')
+    elif isinstance(lookup, list):
+        keys = lookup
+    else:
+        raise TypeError('lookup must be string or list')
+
+    if parent:
+        keys = keys[:-1]
+
+    for key in keys:
+        if isinstance(value, list):
+            key = int(key)
+        value = value[key]
+    return value

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -8,7 +8,94 @@
 
 """Utils gathers helper functions, classes for the dictdiffer module."""
 
-from ._compat import string_types
+from ._compat import string_types, izip_longest
+
+
+class WildcardDict(dict):
+
+    """A dictionary that provides special wildcard keys.
+
+    Those wildcards are:
+        *:  wildcard for everything that follows
+        +:  wildcard for anything on the same path level
+    The intended use case of this are dictionaries, that utilize tuples as
+    keys.
+
+        >>> w = WildcardDict({('foo', '*'): '* card',
+        ...                   ('banana', '+'): '+ card'})
+        >>> w[ ('foo', 'bar', 'baz') ]
+        '* card'
+        >>> w[ ('banana', 'apple') ]
+        '+ card'
+    """
+
+    def __init__(self, values=None):
+        """A dictionary that provides special wildcard keys.
+
+        :param values: a dictionary
+        """
+        super(WildcardDict, self).__init__()
+        self.star_keys = set()
+        self.plus_keys = set()
+
+        if values is not None:
+            for key, value in values.items():
+                self.__setitem__(key, value)
+
+    def __getitem__(self, key):
+        """Return the value corresponding to the key, regarding wildcards.
+
+        If the key doesn't exit it tries the '+' wildcard and then the
+        '*' wildcard.
+
+            >>> w = WildcardDict({('foo', '*'): '* card',
+            ...                   ('banana', '+'): '+ card'})
+            >>> w[ ('foo', 'bar') ]
+            '* card'
+            >>> w[ ('foo', 'bar', 'baz') ]
+            '* card'
+            >>> w[ ('banana', 'apple') ]
+            '+ card'
+            >>> w[ ('banana', 'apple', 'mango') ]
+            Traceback (most recent call last):
+                ...
+            KeyError
+        """
+        try:
+            return super(WildcardDict, self).__getitem__(key)
+        except KeyError:
+            if key[:-1] in self.plus_keys:
+                return super(WildcardDict, self).__getitem__(key[:-1]+('+',))
+            for _key in [key[:-i] for i in range(1, len(key)+1)]:
+                if _key in self.star_keys:
+                    return super(WildcardDict, self).__getitem__(_key+('*',))
+            raise KeyError
+
+    def __setitem__(self, key, value):
+        """Set the item for a given key (path)."""
+        super(WildcardDict, self).__setitem__(key, value)
+
+        if key[-1] == '+':
+            self.plus_keys.add(key[:-1])
+        if key[-1] == '*':
+            self.star_keys.add(key[:-1])
+
+    def query_path(self, key):
+        """Return the key (path) that matches the queried key.
+
+        >>> w = WildcardDict({('foo', '*'): 'banana'})
+        >>> w.query_path(('foo', 'bar', 'baz'))
+        ('foo', '*')
+        """
+        if key in self:
+            return key
+        if key[:-1] in self.plus_keys:
+            return key[:-1]+('+',)
+        for _key in [key[:-i] for i in range(1, len(key)+1)]:
+            if _key in self.star_keys:
+                return _key+('*',)
+
+        raise KeyError
 
 
 class PathLimit(object):
@@ -57,6 +144,66 @@ class PathLimit(object):
                     return False
 
         return containing.get(self.final_key, False)
+
+
+def create_dotted_node(node):
+    """Create the *dotted node* notation for the dictdiffer.diff patches.
+
+    >>> create_dotted_node( ['foo', 'bar', 'baz'] )
+    'foo.bar.baz'
+    """
+    if all(map(lambda x: isinstance(x, string_types), node)):
+        return '.'.join(node)
+    else:
+        return list(node)
+
+
+def get_path(patch):
+    """Return the path for a given dictdiffer.diff patch."""
+    if patch[1] != '':
+        keys = (patch[1].split('.') if isinstance(patch[1], string_types)
+                else patch[1])
+    else:
+        keys = []
+    keys = keys + [patch[2][0][0]] if patch[0] != 'change' else keys
+    return tuple(keys)
+
+
+def is_super_path(path1, path2):
+    """Check if one path is the super path of the other.
+
+    Super path means, that the n values in tuple are equal to the first n of m
+    vales in tuple b.
+
+        >>> is_super_path( ('foo', 'bar'), ('foo', 'bar') )
+        True
+
+        >>> is_super_path( ('foo', 'bar'), ('foo', 'bar', 'baz') )
+        True
+
+        >>> is_super_path( ('foo', 'bar'), ('foo', 'apple', 'banana') )
+        False
+    """
+    return all(map(lambda x: x[0] == x[1] or x[0] is None,
+                   izip_longest(path1, path2)))
+
+
+def nested_hash(obj):
+    """Create a hash of nested, mutable data structures.
+
+    It shall be noted, that the uniqeness of those hashes in general cases is
+    not assured but it should be enough for the cases occurring during the
+    merging process.
+    """
+    try:
+        return hash(obj)
+    except TypeError:
+        if isinstance(obj, (list, tuple)):
+            return hash(tuple(map(nested_hash, obj)))
+        elif isinstance(obj, set):
+            return hash(tuple(map(nested_hash, sorted(obj))))
+        elif isinstance(obj, dict):
+            return hash(tuple(map(nested_hash, sorted(obj.items()))))
 
 
 def dot_lookup(source, lookup, parent=False):

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -17,4 +17,4 @@ This file is imported by ``dictdiffer.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.4.1.dev20150311"
+__version__ = "0.5.0.dev20150414"

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -1,0 +1,93 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import unittest
+
+from dictdiffer.conflict import Conflict, ConflictFinder
+
+
+class ConflictTest(unittest.TestCase):
+    def test_init(self):
+        p1 = ('add', '', [(0, 0)])
+        p2 = ('add', '', [(1, 2)])
+
+        c = Conflict(p1, p2)
+
+        self.assertEqual(c.first_patch, p1)
+        self.assertEqual(c.second_patch, p2)
+        self.assertEqual(c.take, None)
+        self.assertFalse(c.handled)
+
+    def test_take_patch(self):
+        p1 = ('add', '', [(1, 1)])
+        p2 = ('add', '', [(1, -1)])
+
+        c = Conflict(p1, p2)
+
+        self.assertRaises(Exception, c.take_patch)
+
+        c.take = 'f'
+        self.assertEqual(c.take_patch(), p1)
+
+        c.take = 's'
+        self.assertEqual(c.take_patch(), p2)
+
+
+class ConflictFinderTest(unittest.TestCase):
+    def test_is_conflict(self):
+        # SAME LENGTH NO CONFLICT
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(2, 0)])
+
+        c = ConflictFinder()
+        self.assertFalse(c._is_conflict(p1, p2))
+
+        p1 = ('add', 'foo.bar', [(0, 0)])
+        p2 = ('add', 'foo.bar', [(2, 0)])
+
+        c = ConflictFinder()
+        self.assertFalse(c._is_conflict(p1, p2))
+
+        # SAME LENGTH CONFLICT
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 0)])
+
+        c = ConflictFinder()
+        self.assertTrue(c._is_conflict(p1, p2))
+
+        p1 = ('add', 'foo.bar', [(0, 0)])
+        p2 = ('add', 'foo.bar', [(0, 0)])
+
+        c = ConflictFinder()
+        self.assertTrue(c._is_conflict(p1, p2))
+
+        # SUPER PATH
+        p1 = ('remove', '', [('foo', [])])
+        p2 = ('add', 'foo.bar', [(0, 0)])
+
+        c = ConflictFinder()
+        self.assertTrue(c._is_conflict(p1, p2))
+
+        p1 = ('add', 'foo.bar', [(0, 0)])
+        p2 = ('remove', '', [('foo', [])])
+
+        c = ConflictFinder()
+        self.assertTrue(c._is_conflict(p1, p2))
+
+    def test_find_conflicts(self):
+        p11 = ('add', 'foo.bar', [(0, 0)])
+        p12 = ('add', 'foo', [(0, 0)])
+
+        p21 = ('add', 'foo.bar', [(0, 0)])
+        p22 = ('add', 'foo', [(1, 0)])
+
+        conflicts = [Conflict(p11, p21)]
+
+        c = ConflictFinder()
+        self.assertEqual(repr(c.find_conflicts([p11, p12], [p21, p22])),
+                         repr(conflicts))

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,48 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import unittest
+
+from dictdiffer.merge import Merger, UnresolvedConflictsException
+
+
+class MergerTest(unittest.TestCase):
+    def test_run(self):
+        lca = {'changeme': 'Jo'}
+        first = {'changeme': 'Joe'}
+        second = {'changeme': 'John'}
+
+        m = Merger(lca, first, second, {})
+
+        self.assertRaises(UnresolvedConflictsException, m.run)
+
+    def test_continue_run(self):
+        def take_first(conflict, _, __, ___):
+            conflict.take = [('f', x) for x
+                             in range(len(conflict.first_patch.patches))]
+            return True
+
+        lca = {'changeme': 'Jo'}
+        first = {'changeme': 'Joe'}
+        second = {'changeme': 'John'}
+
+        m = Merger(lca, first, second, {})
+
+        try:
+            m.run()
+        except UnresolvedConflictsException:
+            pass
+
+        m.continue_run(['f'])
+
+        self.assertEqual(m.unified_patches,
+                         [('change', 'changeme', ('Jo', 'Joe'))])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,160 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import unittest
+
+from dictdiffer.conflict import Conflict
+from dictdiffer.resolve import (Resolver, UnresolvedConflictsException,
+                                NoFurtherResolutionException)
+
+
+class UnresolvedConflictsExceptionTest(unittest.TestCase):
+    def test_content(self):
+        e = UnresolvedConflictsException(None)
+        self.assertEqual(None, e.content)
+
+    def test_message(self):
+        e = UnresolvedConflictsException(None)
+        m = ("The unresolved conflicts are stored in the *content* "
+             "attribute of this exception or in the "
+             "*unresolved_conflicts* attribute of the "
+             "dictdiffer.merge.Merger object.")
+
+        self.assertEqual(m, str(e))
+        self.assertEqual(m, e.__repr__())
+        self.assertEqual(m, e.__str__())
+
+
+class ResolverTest(unittest.TestCase):
+    def test_init(self):
+        # Very basic
+        r = Resolver({})
+
+        self.assertEqual(r.actions, {})
+        self.assertEqual(r.additional_info, None)
+        self.assertEqual(r.unresolved_conflicts, [])
+
+        # With additional_info
+        r = Resolver({}, {})
+
+        self.assertEqual(r.actions, {})
+        self.assertEqual(r.additional_info, {})
+        self.assertEqual(r.unresolved_conflicts, [])
+
+    def test_auto_resolve(self):
+        r = Resolver({})
+        # Sucessful
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 0)])
+        c = Conflict(p1, p2)
+
+        self.assertTrue(r._auto_resolve(c))
+        self.assertEqual(c.take, 'f')
+
+        # Fail
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 1)])
+        c = Conflict(p1, p2)
+
+        self.assertFalse(r._auto_resolve(c))
+
+    def test_find_conflicting_path(self):
+        r = Resolver({})
+
+        # A = shortest
+        p1 = ('delete', '', [('foo', [])])
+        p2 = ('add', 'foo', [(0, 0)])
+        c = Conflict(p1, p2)
+
+        self.assertEqual(r._find_conflicting_path(c), ('foo',))
+
+        # Same
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 0)])
+        c = Conflict(p1, p2)
+
+        self.assertEqual(r._find_conflicting_path(c), ('foo', 0))
+
+        # B = shortest
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('delete', '', [('foo', [])])
+        c = Conflict(p1, p2)
+
+        self.assertEqual(r._find_conflicting_path(c), ('foo',))
+
+    def test_consecutive_slices(self):
+        r = Resolver({})
+
+        slices = [['foo', 'bar', 'apple', 'banana'], ['foo', 'bar', 'apple'],
+                  ['foo', 'bar'], ['foo']]
+
+        self.assertEqual(list(r._consecutive_slices(['foo',
+                                                     'bar',
+                                                     'apple',
+                                                     'banana'])), slices)
+
+    def test_resolve_conflicts(self):
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 1)])
+        c = [Conflict(p1, p2)]
+
+        # KeyError
+        r = Resolver({})
+
+        self.assertRaises(UnresolvedConflictsException,
+                          r.resolve_conflicts, [p1], [p2], c)
+
+        # Failing action
+        r = Resolver({('foo', 0): lambda w, x, y, z: False})
+
+        self.assertRaises(UnresolvedConflictsException,
+                          r.resolve_conflicts, [p1], [p2], c)
+
+        # No further resolution exception
+        def no_further(w, x, y, z):
+            raise NoFurtherResolutionException
+
+        r = Resolver({('foo', 0): no_further})
+        self.assertRaises(UnresolvedConflictsException,
+                          r.resolve_conflicts, [p1], [p2], c)
+
+        # Succesful
+        r = Resolver({('foo', 0): lambda w, x, y, z: True})
+        r.resolve_conflicts([p1], [p2], c)
+
+        self.assertEqual(r.unresolved_conflicts, [])
+
+        # Succesful auto resolve
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 0)])
+        c = [Conflict(p1, p2)]
+
+        r = Resolver({})
+        r.resolve_conflicts([p1], [p2], c)
+
+        self.assertEqual(r.unresolved_conflicts, [])
+
+    def test_manual_resolve_conflicts(self):
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 0)])
+        c = Conflict(p1, p2)
+
+        r = Resolver({})
+        r.unresolved_conflicts.append(c)
+
+        r.manual_resolve_conflicts(['s'])
+
+        self.assertEqual(c.take, 's')
+
+        # Raise
+        r = Resolver({})
+        r.unresolved_conflicts.append(c)
+
+        self.assertRaises(UnresolvedConflictsException,
+                          r.manual_resolve_conflicts,
+                          [])

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -1,0 +1,42 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import unittest
+
+from dictdiffer import patch
+from dictdiffer.conflict import Conflict
+from dictdiffer.merge import Merger
+from dictdiffer.unify import Unifier
+from dictdiffer.utils import WildcardDict, nested_hash
+
+
+class TestUnifier(unittest.TestCase):
+
+    def test_build_index(self):
+        u = Unifier()
+
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 1)])
+        c = Conflict(p1, p2)
+
+        u._build_index([c])
+
+        self.assertEqual(u._index[nested_hash(p1)], c)
+        self.assertEqual(u._index[nested_hash(p2)], c)
+
+    def test_unify(self):
+        u = Unifier()
+
+        p1 = ('add', 'foo', [(0, 0)])
+        p2 = ('add', 'foo', [(0, 1)])
+        c = Conflict(p1, p2)
+        c.take = 'f'
+
+        u.unify([p1], [p2], [c])
+
+        self.assertEqual(u.unified_patches, [p1])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,10 +8,58 @@
 
 import unittest
 
-from dictdiffer.utils import PathLimit, dot_lookup
+from dictdiffer.utils import (WildcardDict, PathLimit, create_dotted_node,
+                              get_path, is_super_path, dot_lookup,
+                              nested_hash)
 
 
 class UtilsTest(unittest.TestCase):
+    def test_wildcarddict(self):
+        wd = WildcardDict()
+
+        wd[('authors', '*')] = True
+
+        self.assertRaises(KeyError, wd.__getitem__, ('authors',))
+        self.assertTrue(wd[('authors', 1)])
+        self.assertTrue(wd[('authors', 1, 'name')])
+        self.assertTrue(wd[('authors', 1, 'affiliation')])
+
+        del wd[('authors', '*')]
+
+        wd[('authors', '+')] = True
+
+        self.assertRaises(KeyError, wd.__getitem__, ('authors',))
+        self.assertTrue(wd[('authors', 1)])
+        self.assertRaises(KeyError, wd.__getitem__, ('authors', 1, 'name'))
+        self.assertRaises(KeyError, wd.__getitem__, ('authors', 1,
+                                                     'affiliation'))
+
+        del wd[('authors', '+')]
+
+        wd[('foo', 'bar')] = True
+
+        self.assertRaises(KeyError, wd.__getitem__, ('foo',))
+        self.assertTrue(wd[('foo', 'bar')])
+        self.assertRaises(KeyError, wd.__getitem__, ('foo', 'bar', 'banana'))
+
+        # query_path part
+        wd = WildcardDict()
+        wd[('authors', '*')] = True
+        wd[('apple', '+')] = True
+        wd[('foo', 'bar')] = True
+
+        self.assertRaises(KeyError, wd.query_path, ('utz',))
+        self.assertRaises(KeyError, wd.query_path, ('foo',))
+        self.assertRaises(KeyError, wd.query_path, ('bar',))
+        self.assertRaises(KeyError, wd.query_path, ('apple', 'banana',
+                                                    'mango'))
+        self.assertEqual(('authors', '*'), wd.query_path(('authors', 1)))
+        self.assertEqual(('authors', '*'), wd.query_path(('authors', 1, 1)))
+        self.assertEqual(('authors', '*'), wd.query_path(('authors', 1, 1, 1)))
+        self.assertEqual(('apple', '+'), wd.query_path(('apple', 'banana')))
+        self.assertEqual(('apple', '+'), wd.query_path(('apple', 'mango')))
+        self.assertEqual(('foo', 'bar'), wd.query_path(('foo', 'bar')))
+
     def test_pathlimit(self):
         path_limit = PathLimit([('author', 'name')])
         self.assertFalse(path_limit.path_is_limit(('author')))
@@ -25,6 +73,62 @@ class UtilsTest(unittest.TestCase):
         self.assertTrue(path_limit.path_is_limit(('authors', 2)))
         self.assertFalse(path_limit.path_is_limit(('authors', 'name', 'foo')))
 
+    def test_create_dotted_node(self):
+        node = ('foo', 'bar')
+        self.assertEqual('foo.bar', create_dotted_node(node))
+
+        node = ('foo', 1)
+        self.assertEqual(['foo', 1], create_dotted_node(node))
+
+        node = ('foo', 1, 'bar')
+        self.assertEqual(['foo', 1, 'bar'], create_dotted_node(node))
+
+    def test_get_path(self):
+        patch = ('add/delete', '', [('author', 'Bob')])
+        self.assertEqual(('author',), get_path(patch))
+        patch = ('add/delete', 'authors', [('name', 'Bob')])
+        self.assertEqual(('authors', 'name'), get_path(patch))
+        patch = ('add/delete', 'foo.bar', [('name', 'Bob')])
+        self.assertEqual(('foo', 'bar', 'name'), get_path(patch))
+        patch = ('add/delete', ['foo', 1], [('name', 'Bob')])
+        self.assertEqual(('foo', 1, 'name'), get_path(patch))
+
+        patch = ('change', 'foo', [('John', 'Bob')])
+        self.assertEqual(('foo',), get_path(patch))
+        patch = ('change', 'foo.bar', [('John', 'Bob')])
+        self.assertEqual(('foo', 'bar'), get_path(patch))
+        patch = ('change', ['foo', 'bar'], [('John', 'Bob')])
+        self.assertEqual(('foo', 'bar'), get_path(patch))
+        patch = ('change', ['foo', 1], [('John', 'Bob')])
+        self.assertEqual(('foo', 1), get_path(patch))
+
+    def test_is_super_path(self):
+        # # True
+        path1 = ('authors', 1, 'name')
+        path2 = ('authors', 1, 'name')
+        self.assertTrue(is_super_path(path1, path2))
+
+        path1 = ('authors', 1)
+        path2 = ('authors', 1, 'name')
+        self.assertTrue(is_super_path(path1, path2))
+
+        path1 = ('authors',)
+        path2 = ('authors', 1, 'name')
+        self.assertTrue(is_super_path(path1, path2))
+
+        # # False
+        path1 = ('authors', 1, 'name')
+        path2 = ('authors', 1, 'surname')
+        self.assertFalse(is_super_path(path1, path2))
+
+        path1 = ('authors', 2)
+        path2 = ('authors', 1, 'surname')
+        self.assertFalse(is_super_path(path1, path2))
+
+        path1 = ('author',)
+        path2 = ('authors', 1, 'surname')
+        self.assertFalse(is_super_path(path1, path2))
+
     def test_dot_lookup(self):
         self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, 'a.b'), 'hello')
         self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, ['a', 'b']),
@@ -34,3 +138,10 @@ class UtilsTest(unittest.TestCase):
                          {'b': 'hello'})
         self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, ''),
                          {'a': {'b': 'hello'}})
+
+    def test_nested_hash(self):
+        # No reasonable way to test this
+        nested_hash([1, 2, 3])
+        nested_hash((1, 2, 3))
+        nested_hash(set([1, 2, 3]))
+        nested_hash({'foo': 'bar'})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2015 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+import unittest
+
+from dictdiffer.utils import PathLimit, dot_lookup
+
+
+class UtilsTest(unittest.TestCase):
+    def test_pathlimit(self):
+        path_limit = PathLimit([('author', 'name')])
+        self.assertFalse(path_limit.path_is_limit(('author')))
+        self.assertTrue(path_limit.path_is_limit(('author', 'name')))
+        self.assertFalse(path_limit.path_is_limit(('author', 'name', 'foo')))
+
+        path_limit = PathLimit([('authors', '*')])
+        self.assertFalse(path_limit.path_is_limit(('authors')))
+        self.assertTrue(path_limit.path_is_limit(('authors', 'name')))
+        self.assertTrue(path_limit.path_is_limit(('authors', 1)))
+        self.assertTrue(path_limit.path_is_limit(('authors', 2)))
+        self.assertFalse(path_limit.path_is_limit(('authors', 'name', 'foo')))
+
+    def test_dot_lookup(self):
+        self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, 'a.b'), 'hello')
+        self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, ['a', 'b']),
+                         'hello')
+
+        self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, 'a.b', parent=True),
+                         {'b': 'hello'})
+        self.assertEqual(dot_lookup({'a': {'b': 'hello'}}, ''),
+                         {'a': {'b': 'hello'}})


### PR DESCRIPTION
As discussed with @jirikuncar a while ago, here the pull request of a more pragmatic dictdiffer.merge implementation.

Dictdiffer v0.5.0: merging

* Alters the dictdiffer.diff function to allow expanding patches and to utilize a path_limit parameter, which stops the extraction process at a given point
* Adds the following files to handle the merging process:
  * merge.py
  * conflict.py
  * resolve.py
  * unify.py

Which is executed in the following steps:
* The differences between a latest common ancestor (lca) and two other data structures are extracted
* The two occuring differences lists are checked for conflicts
* Those conficts are resolved
* The patches are unified

Signed-off-by: Martin Vesper <martin.vesper@cern.ch>