### PR TITLE
diff: add tolerance parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Contributors:
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Jason Peddle <jwpeddle@gmail.com>
 * Martin Vesper <martin.vesper@cern.ch>
+* Gilles DAVID <frodon1@gmail.com>

--- a/dictdiffer/_compat.py
+++ b/dictdiffer/_compat.py
@@ -14,6 +14,7 @@ import sys
 if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
     string_types = str,
     text_type = str
+    num_types = int, float
     PY2 = False
 
     from itertools import zip_longest as _zip_longest
@@ -21,6 +22,7 @@ if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
 else:  # pragma: no cover (Python 2/3 specific code)
     string_types = basestring,
     text_type = unicode
+    num_types = int, long, float
     PY2 = True
 
     from itertools import izip_longest as _zip_longest

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -8,7 +8,11 @@
 
 """Utils gathers helper functions, classes for the dictdiffer module."""
 
-from ._compat import string_types, izip_longest
+import sys
+
+from ._compat import string_types, num_types, izip_longest
+
+EPSILON = sys.float_info.epsilon
 
 
 class WildcardDict(dict):
@@ -245,3 +249,16 @@ def dot_lookup(source, lookup, parent=False):
             key = int(key)
         value = value[key]
     return value
+
+
+def are_different(first, second, tolerance):
+    """Check if 2 values are different.
+
+    In case of numerical values, the tolerance is used to check if the values
+    are different.
+    In all other cases, the difference is straight forward.
+    """
+    if all(map(lambda x: isinstance(x, num_types), [first, second])):
+        return abs(first-second) > tolerance * max(abs(first), abs(second))
+    else:
+        return first != second

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-============
- Dictdiffer
-============
+==========
+Dictdiffer
+==========
 .. currentmodule:: dictdiffer
 
 .. raw:: html
@@ -96,6 +96,27 @@ Let's revert the last changes:
     reverted = revert(result, patched)
     assert reverted == first
 
+A tolerance can be used to consider closed values as equal.
+The tolerance parameter only applies for int and float.
+
+Let's try with a tolerance of 10% with the values 10 and 10.5:
+
+.. code-block:: python
+
+    first = {'a': 10.0}
+    second = {'a': 10.5}
+    
+    result = diff(first, second, tolerance=0.1)
+    
+    assert list(result) == []
+    
+Now with a tolerance of 1%:
+
+.. code-block:: python
+
+    result = diff(first, second, tolerance=0.01)
+    
+    assert list(result) == ('change', 'a', (10.0, 10.5))
 
 API
 ===

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -54,6 +54,30 @@ class DictDifferTests(unittest.TestCase):
         diffed = next(diff(first, second))
         assert ('change', 'a', ('b', None)) == diffed
 
+        first = {'a': 10.0}
+        second = {'a': 10.5}
+        diffed = next(diff(first, second))
+        assert ('change', 'a', (10.0, 10.5)) == diffed
+
+    def test_tolerance(self):
+        first = {'a': 'b'}
+        second = {'a': 'c'}
+        diffed = next(diff(first, second, tolerance=0.1))
+        assert ('change', 'a', ('b', 'c')) == diffed
+
+        first = {'a': None}
+        second = {'a': 'c'}
+        diffed = next(diff(first, second, tolerance=0.1))
+        assert ('change', 'a', (None, 'c')) == diffed
+
+        first = {'a': 10.0}
+        second = {'a': 10.5}
+        diffed = list(diff(first, second, tolerance=0.1))
+        assert [] == diffed
+
+        diffed = next(diff(first, second, tolerance=0.01))
+        assert ('change', 'a', (10.0, 10.5)) == diffed
+
     def test_path_limit_as_list(self):
         first = {}
         second = {'author': {'last_name': 'Doe', 'first_name': 'John'}}


### PR DESCRIPTION
This patch allows to deal with a tolerance when comparing 2 numerical values.
Currently, only int, long (for PY2) and float types use this new parameter.