### PR TITLE
global: support for Python 3.5 and wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # This file is part of Dictdiffer.
 #
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -15,6 +15,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 
 install:
   - pip install --upgrade pip
@@ -32,3 +33,13 @@ after_success:
 
 notifications:
   email: false
+
+deploy:
+  provider: pypi
+  user: jirikuncar
+  password:
+    secure: tntrBrJuE3sqJcLxxbzPGj6zltrP/7GgSOFt7q/wn20JWc1SHhutkFqzO2DMShT4YZBlCwwL4jCLsVdMtARCsBIh/p2glTDLFAKC7DfSqwzsnGk/6Q5uyB7NOn7/GPXItyGEJB8cb6QgsMlpMCqv7+mjrL8+HhWVCaZz4B9lzeY=
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true
+    repo: inveniosoftware/dictdiffer

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -17,4 +17,4 @@ This file is imported by ``dictdiffer.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.5.1.dev20160104"
+__version__ = "0.5.0.post1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+# This file is part of Dictdiffer.
+#
+# Copyright (C) 2016 CERN.
+#
+# Dictdiffer is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2013 Fatih Erikli.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -78,6 +78,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
* Adds support for Python 3.5 and wheels.

* Adds deploy section for automatic PyPI releases.  (closes #64)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>