### PR TITLE
diff: support for collection.abc subclasses

### DIFF
--- a/dictdiffer/_compat.py
+++ b/dictdiffer/_compat.py
@@ -1,6 +1,6 @@
 # This file is part of Dictdiffer.
 #
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -17,6 +17,7 @@ if sys.version_info[0] == 3:  # pragma: no cover (Python 2/3 specific code)
     num_types = int, float
     PY2 = False
 
+    from collections.abc import MutableMapping, MutableSet, MutableSequence
     from itertools import zip_longest as _zip_longest
     izip_longest = _zip_longest
 else:  # pragma: no cover (Python 2/3 specific code)
@@ -25,5 +26,6 @@ else:  # pragma: no cover (Python 2/3 specific code)
     num_types = int, long, float
     PY2 = True
 
+    from collections import MutableMapping, MutableSet, MutableSequence
     from itertools import izip_longest as _zip_longest
     izip_longest = _zip_longest


### PR DESCRIPTION
* NEW Adds support for comparing mutable mappings, sequences and sets
  from `collections.abs` module.  (closes #67)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>