### PR TITLE
unify: unified_patches order fix

### DIFF
--- a/dictdiffer/conflict.py
+++ b/dictdiffer/conflict.py
@@ -25,7 +25,6 @@ class Conflict(object):
         self.first_patch = patch1
         self.second_patch = patch2
         self.take = None
-        self.handled = False
 
     def take_patch(self):
         """Return the patch determined by the *take* attribute."""

--- a/dictdiffer/unify.py
+++ b/dictdiffer/unify.py
@@ -24,19 +24,20 @@ class Unifier(object):
         :param conflicts: list of Conflict objects
         """
         self.unified_patches = []
-        sorted_patches = sorted(first_patches + second_patches, key=get_path)
-
         self._build_index(conflicts)
+
+        sorted_patches = sorted(first_patches + second_patches, key=get_path)
 
         for patch in sorted_patches:
             conflict = self._index.get(nested_hash(patch))
 
+            # Apply only the patches that were taken as part of conflict
+            # resolution.
             if conflict:
-                if not conflict.handled:
-                    conflict.handled = True
-                    self.unified_patches.append(conflict.take_patch())
-            else:
-                self.unified_patches.append(patch)
+                if conflict.take_patch() != patch:
+                    continue
+
+            self.unified_patches.append(patch)
 
         return self.unified_patches
 

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -21,7 +21,6 @@ class ConflictTest(unittest.TestCase):
         self.assertEqual(c.first_patch, p1)
         self.assertEqual(c.second_patch, p2)
         self.assertEqual(c.take, None)
-        self.assertFalse(c.handled)
 
     def test_take_patch(self):
         p1 = ('add', '', [(1, 1)])


### PR DESCRIPTION
* Fixes the way patches are chosen to be part of the final result.

* Adds regression tests for the added fix.

Signed-off-by: Mihai Bivol <miha.bivol@cern.ch>