### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,7 @@ Authors
 
 Dictdiffer was originally developed by Fatih Erikli.  It is now being
 developed and maintained by the Invenio collaboration.  You can
-contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_.
+contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_.
 
 Contributors:
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -41,7 +41,7 @@ Documentation
 Happy hacking and thanks for flying Dictdiffer.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/dictdiffer

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     description=__doc__,
     long_description=readme + '\n\n' + history,
     author='Invenio Collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/dictdiffer',
     packages=['dictdiffer'],
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>