### PR TITLE
docs: diff argument clarification

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -46,45 +46,56 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
 
     Return iterator with differences between two dictionaries.
 
-        >>> from dictdiffer import diff
-        >>> result = diff({'a':'b'}, {'a':'c'})
-        >>> list(result)
-        [('change', 'a', ('b', 'c'))]
+    >>> from dictdiffer import diff
+    >>> result = diff({'a':'b'}, {'a':'c'})
+    >>> list(result)
+    [('change', 'a', ('b', 'c'))]
 
-    PathLimit:
+    The keys can be skipped from difference calculation when they are included
+    in ``ignore`` argument of type :class:`collections.Container`.
 
-        >>> list(diff({}, {'a': {'b': 'c'}}))
-        [('add', '', [('a', {'b': 'c'})])]
+    >>> list(diff({'a': 1, 'b': 2}, {'a': 3, 'b': 4}, ignore=set(['a'])))
+    [('change', 'b', (2, 4))]
+    >>> class IgnoreCase(set):
+    ...     def __contains__(self, key):
+    ...         return set.__contains__(self, str(key).lower())
+    >>> list(diff({'a': 1, 'b': 2}, {'A': 3, 'b': 4}, ignore=IgnoreCase('a')))
+    [('change', 'b', (2, 4))]
 
-        >>> from dictdiffer.utils import PathLimit
-        >>> list(diff({}, {'a': {'b': 'c'}}, path_limit=PathLimit()))
-        [('add', '', [('a', {})]), ('add', 'a', [('b', 'c')])]
+    The difference calculation can be limitted to certain path:
 
-        >>> from dictdiffer.utils import PathLimit
-        >>> list(diff({}, {'a': {'b': 'c'}}, path_limit=PathLimit([('a',)])))
-        [('add', '', [('a', {'b': 'c'})])]
+    >>> list(diff({}, {'a': {'b': 'c'}}))
+    [('add', '', [('a', {'b': 'c'})])]
 
-        >>> from dictdiffer.utils import PathLimit
-        >>> list(diff({}, {'a': {'b': 'c'}},
-        ...           path_limit=PathLimit([('a', 'b')])))
-        [('add', '', [('a', {})]), ('add', 'a', [('b', 'c')])]
+    >>> from dictdiffer.utils import PathLimit
+    >>> list(diff({}, {'a': {'b': 'c'}}, path_limit=PathLimit()))
+    [('add', '', [('a', {})]), ('add', 'a', [('b', 'c')])]
 
-    Expand:
+    >>> from dictdiffer.utils import PathLimit
+    >>> list(diff({}, {'a': {'b': 'c'}}, path_limit=PathLimit([('a',)])))
+    [('add', '', [('a', {'b': 'c'})])]
 
-        ... list(diff({}, {'foo': 'bar', 'apple': 'mango'}))
-        [('add', '', [('foo', 'bar'), ('apple', 'mango')])]
+    >>> from dictdiffer.utils import PathLimit
+    >>> list(diff({}, {'a': {'b': 'c'}},
+    ...           path_limit=PathLimit([('a', 'b')])))
+    [('add', '', [('a', {})]), ('add', 'a', [('b', 'c')])]
 
-        ... list(diff({}, {'foo': 'bar', 'apple': 'mango'}, expand=True))
-        [('add', '', [('foo', 'bar')]), ('add', '', [('apple', 'mango')])]
+    The patch can be expanded to small units e.g. when adding multiple values:
 
-    :param first: original dictionary, list or set
-    :param second: new dictionary, list or set
-    :param node: key for comparison that can be used in :func:`dot_lookup`
-    :param ignore: list of keys that should not be checked
+    >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}))
+    [('add', 'fruits', [(0, 'apple'), (1, 'mango')])]
+
+    >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}, expand=True))
+    [('add', 'fruits', [(0, 'apple')]), ('add', 'fruits', [(1, 'mango')])]
+
+    :param first: The original dictionary, ``list`` or ``set``.
+    :param second: New dictionary, ``list`` or ``set``.
+    :param node: Key for comparison that can be used in :func:`dot_lookup`.
+    :param ignore: List of keys that should not be checked.
     :param path_limit: List of path limit tuples or dictdiffer.utils.Pathlimit
-                       object to limit the diff recursion depth
-    :param expand: Expands the patches
-    :param tolerance: threshold to consider 2 values identical
+                       object to limit the diff recursion depth.
+    :param expand: Expand the patches.
+    :param tolerance: Threshold to consider when comparing two float numbers.
 
     .. versionchanged:: 0.3
        Added *ignore* parameter.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Dictdiffer.
 #
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -47,12 +47,17 @@ except ImportError:
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+# Do not warn on external images.
+suppress_warnings = ['image.nonlocal_uri']
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
     'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -77,7 +82,8 @@ copyright = u'2014, Fatih Erikli'
 #
 # The short X.Y version.
 
-with open(os.path.join('..', 'dictdiffer', 'version.py'), 'rt') as f:
+with open(os.path.join(os.path.dirname(__file__), '..', 'dictdiffer',
+                       'version.py'), 'rt') as f:
     version = re.search(
         '__version__\s*=\s*"(?P<version>.*)"\n',
         f.read()
@@ -289,3 +295,9 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# Example configuration for intersphinx: refer to the Python standard library.
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/2.7', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,18 +3,20 @@ Dictdiffer
 ==========
 .. currentmodule:: dictdiffer
 
-.. raw:: html
+.. image:: https://img.shields.io/travis/inveniosoftware/dictdiffer.svg
+        :target: https://travis-ci.org/inveniosoftware/dictdiffer
 
-    <p style="height:22px; margin:0 0 0 2em; float:right">
-        <a href="https://travis-ci.org/inveniosoftware/dictdiffer">
-            <img src="https://travis-ci.org/inveniosoftware/dictdiffer.svg?branch=master"
-                 alt="travis-ci badge"/>
-        </a>
-        <a href="https://coveralls.io/r/inveniosoftware/dictdiffer">
-            <img src="https://coveralls.io/repos/inveniosoftware/dictdiffer/badge.svg?branch=master"
-                 alt="coveralls.io badge"/>
-        </a>
-    </p>
+.. image:: https://img.shields.io/coveralls/inveniosoftware/dictdiffer.svg
+        :target: https://coveralls.io/r/inveniosoftware/dictdiffer
+
+.. image:: https://img.shields.io/github/tag/inveniosoftware/dictdiffer.svg
+        :target: https://github.com/inveniosoftware/dictdiffer/releases
+
+.. image:: https://img.shields.io/pypi/dm/dictdiffer.svg
+        :target: https://pypi.python.org/pypi/dictdiffer
+
+.. image:: https://img.shields.io/github/license/inveniosoftware/dictdiffer.svg
+        :target: https://github.com/inveniosoftware/dictdiffer/blob/master/LICENSE
 
 Dictdiffer is a helper module that helps you to diff and patch
 dictionaries.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,11 @@
 # This file is part of Dictdiffer.
 #
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 [pytest]
-addopts = --pep8 --ignore=docs --doctest-modules --cov=dictdiffer --cov-report=term-missing tests dictdiffer
+pep8ignore = docs/conf.py ALL
+addopts = --pep8 --doctest-glob='*.rst' --doctest-modules --cov=dictdiffer --cov-report=term-missing docs tests dictdiffer

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,5 +13,4 @@ pydocstyle dictdiffer && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test && \
-sphinx-build -qnNW -b doctest docs docs/_build/doctest
+python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         'unittest2>=1.1.0',
     ],
     'docs': [
-        'Sphinx>=1.3',
+        'Sphinx>=1.4.4',
         'sphinx-rtd-theme>=0.1.9',
     ],
     'numpy': [


### PR DESCRIPTION
* Improves API documentation for `ignore` argument in `diff` function.
  (addresses #79)

* Executes doctests during PyTest invocation.

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>