### PR TITLE
docs: new maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,2 @@
 Jiri Kuncar <jiri.kuncar@cern.ch> (@jirikuncar)
+Tibor Simko <tibor.simko@cern.ch> (@tiborsimko)


### PR DESCRIPTION
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>