### PR TITLE
swap: reversed order of REMOVE items

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -292,9 +292,9 @@ def swap(diff_result):
     In addition, swap the changed values for `change` flag.
 
         >>> from dictdiffer import swap
-        >>> swapped = swap([('add', 'a.b.c', ('a', 'b'))])
+        >>> swapped = swap([('add', 'a.b.c', [('a', 'b'), ('c', 'd')])])
         >>> next(swapped)
-        ('remove', 'a.b.c', ('a', 'b'))
+        ('remove', 'a.b.c', [('c', 'd'), ('a', 'b')])
 
         >>> swapped = swap([('change', 'a.b.c', ('a', 'b'))])
         >>> next(swapped)
@@ -302,7 +302,7 @@ def swap(diff_result):
 
     """
     def add(node, changes):
-        return REMOVE, node, changes
+        return REMOVE, node, list(reversed(changes))
 
     def remove(node, changes):
         return ADD, node, changes

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -568,6 +568,13 @@ class SwapperTests(unittest.TestCase):
         reverted = revert(diffed, second)
         assert reverted == first
 
+    def test_list_of_different_length(self):
+        """Check that one can revert list with different length."""
+        first = [1]
+        second = [1, 2, 3]
+        result = list(diff(first, second))
+        assert first == revert(result, second)
+
 
 class DotLookupTest(unittest.TestCase):
     def test_list_lookup(self):


### PR DESCRIPTION
* FIX Changes order of items for REMOVE section of generated patches
  when `swap` is called so the list items are removed from the end.
  (closes #85)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>