### PR TITLE
diff: deep copy of unhashable types

### DIFF
--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -63,6 +63,14 @@ class DictDifferTests(unittest.TestCase):
         diffed = next(diff(first, second))
         assert ('change', 'a', (10.0, 10.5)) == diffed
 
+    def test_immutable_diffs(self):
+        first = {'a': 'a'}
+        second = {'a': {'b': 'b'}}
+        result = list(diff(first, second))
+        assert result[0][2][1]['b'] == 'b'
+        second['a']['b'] = 'c'  # result MUST stay unchanged
+        assert result[0][2][1]['b'] == 'b'
+
     def test_tolerance(self):
         first = {'a': 'b'}
         second = {'a': 'c'}


### PR DESCRIPTION
* INCOMPATIBLE Fixes problem with diff results that reference the
  original structure by introduction of `deepcopy` for all possibly
  unhashable items. Thus the diff does not change later when the
  diffed structures change.

cc @mikaelho