### PR TITLE
global: removal of support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2014, 2016 CERN.
+# Copyright (C) 2017 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -14,11 +15,10 @@ cache:
   - pip
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 before_install:
   - "travis_retry pip install --upgrade pip setuptools py"

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,7 @@ Contributors:
 * Brian Rue <brianrue@gmail.com>
 * Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>
-* Jiri Kuncar <jiri.kuncar@cern.ch>
+* Jiri Kuncar <jiri.kuncar@gmail.com>
 * Jason Peddle <jwpeddle@gmail.com>
 * Martin Vesper <martin.vesper@cern.ch>
 * Gilles DAVID <frodon1@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2013 Fatih Erikli.
 # Copyright (C) 2014, 2015, 2016 CERN.
+# Copyright (C) 2017 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -80,12 +81,11 @@ setup(
     tests_require=tests_require,
     classifiers=[
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2014 CERN.
+# Copyright (C) 2017 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
 # details.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
* Adds Python 3.6 to test matrix.

--
@tiborsimko can you please remove the LGTM status check and maybe enable review?