### PR TITLE
fix unicode sub key bug

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -134,7 +134,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 new_key = key
             return ignore is None \
                 or (node + [key] if isinstance(dotted_node, LIST_TYPES)
-                    else '.'.join(node + [str(new_key)])) not in ignore
+                    else '.'.join([str(x) for x in node if isinstance(x, str)] + [str(new_key)])) not in ignore
 
         intersection = [k for k in first if k in second and check(k)]
         addition = [k for k in second if k not in first and check(k)]

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -134,7 +134,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 new_key = key
             return ignore is None \
                 or (node + [key] if isinstance(dotted_node, LIST_TYPES)
-                    else '.'.join([str(x) for x in node if isinstance(x, str)] + [str(new_key)])) not in ignore
+                    else '.'.join([str(x) for x in node if isinstance(x, str)] +  # noqa E501
+                                  [str(new_key)])) not in ignore
 
         intersection = [k for k in first if k in second and check(k)]
         addition = [k for k in second if k not in first and check(k)]

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -134,7 +134,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 new_key = key
             return ignore is None \
                 or (node + [key] if isinstance(dotted_node, LIST_TYPES)
-                    else '.'.join([str(x) for x in node if isinstance(x, str)] +  # noqa E501
+                    else '.'.join([str(x) for x in node
+                                   if isinstance(x, str)] +
                                   [str(new_key)])) not in ignore
 
         intersection = [k for k in first if k in second and check(k)]

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -265,13 +265,13 @@ class DictDifferTests(unittest.TestCase):
         assert ('change', 'a.ac', ('C', 3)) == diffed
 
     def test_ignore_with_unicode_sub_keys(self):
-        first = {u'bill': {u'למה': {u'time': 1506756440000}}}
-        second = {u'bill': {u'למה': {u'time': 1506756440001}}}
+        first = {u'a': {u'aא': {u'aa': 'A'}}}
+        second = {u'a': {u'aא': {u'aa': 'B'}}}
 
         assert len(list(diff(first, second))) == 1
-        assert len(list(diff(first, second, ignore=[u'bill.למה.time']))) == 0
+        assert len(list(diff(first, second, ignore=[u'a.aא.aa']))) == 0
         assert len(
-            list(diff(first, second, ignore=[[u'bill', u'למה', u'time']
+            list(diff(first, second, ignore=[[u'a', u'aא', u'aa']
                                              ]))) == 0
 
     def test_ignore_complex_key(self):

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -262,14 +262,14 @@ class DictDifferTests(unittest.TestCase):
         assert ('change', 'a.ac', ('C', 3)) == diffed
 
     def test_ignore_with_unicode_sub_keys(self):
-        first = second = {
-                            u"bill": {
-                                u"למה": {
-                                    u"time": 1506756440000
-                                }
-                            }
-                         }
-        assert len(list(diff(first, second, ignore=['any', 'key']))) == 0
+        first = {
+                    u"a": {
+                        u"aא": {
+                            u"aaa": "A"
+                        }
+                    }
+                 }
+        assert len(list(diff(first, first, ignore=['any', 'key']))) == 0
 
     def test_ignore_complex_key(self):
         first = {'a': {1: {'a': 'a', 'b': 'b'}}}

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -261,6 +261,16 @@ class DictDifferTests(unittest.TestCase):
         diffed = next(diff(first, second, ignore=['a.aa']))
         assert ('change', 'a.ac', ('C', 3)) == diffed
 
+    def test_ignore_with_unicode_sub_keys(self):
+        first = second = {
+                            u"bill": {
+                                u"למה": {
+                                    u"time": 1506756440000
+                                }
+                            }
+                         }
+        assert len(list(diff(first, second, ignore=['any', 'key']))) == 0
+
     def test_ignore_complex_key(self):
         first = {'a': {1: {'a': 'a', 'b': 'b'}}}
         second = {'a': {1: {'a': 1, 'b': 2}}}


### PR DESCRIPTION
Found a bug where if a sub key is unicode then we get an exception.
Added test case example.