### PR TITLE
unify: unified_patches duplicates fix

### DIFF
--- a/dictdiffer/unify.py
+++ b/dictdiffer/unify.py
@@ -37,7 +37,8 @@ class Unifier(object):
                 if conflict.take_patch() != patch:
                     continue
 
-            self.unified_patches.append(patch)
+            if patch not in self.unified_patches:
+                self.unified_patches.append(patch)
 
         return self.unified_patches
 

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -40,3 +40,15 @@ class TestUnifier(unittest.TestCase):
         u.unify([p1], [p2], [c])
 
         self.assertEqual(u.unified_patches, [p1])
+
+    def test_unify_duplicate_patches(self):
+        u = Unifier()
+
+        p1 = ('remove', '', [('a', 'b')])
+        p2 = ('remove', '', [('a', 'b')])
+        c = Conflict(p1, p2)
+        c.take = 'f'
+
+        u.unify([p1], [p2], [c])
+
+        self.assertEqual(u.unified_patches, [p1])


### PR DESCRIPTION
* FIX Fixes the way in which handled conflicts are unified so that the
  Merger's unified_patches does not contain duplicate patches and can
  always be applied.

* Related issue: https://github.com/inveniosoftware/dictdiffer/issues/109

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>