### PR TITLE
unify: sorting causes IndexError

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -64,6 +64,26 @@ class MergerTest(unittest.TestCase):
             self.assertEqual(patch(m.unified_patches, lca),
                              expected_value)
 
+    def test_continue_run_multiple_conflicts_per_patch_two(self):
+        lca = {'foo': [{'x': 1}, {'y': 2}, {'z': 4}, {'q': 5}]}
+        first = {'foo': [{'x': 1}]}
+        second = {'bar': 'baz'}
+
+        expected = {
+            'f': {'foo': [{'x': 1}],
+                  'bar': 'baz'},
+            's': {'bar': 'baz'}}
+
+        for resolution, expected_value in expected.items():
+            m = Merger(lca, first, second, {})
+            try:
+                m.run()
+            except UnresolvedConflictsException as e:
+                m.continue_run([resolution for _ in e.content])
+
+            self.assertEqual(patch(m.unified_patches, lca),
+                             expected_value)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The sorting done by unify [here](https://github.com/inveniosoftware/dictdiffer/blob/master/dictdiffer/unify.py#L29) is breaking the descending order in sequences of patches that remove certain elements of a list that can be found at particular indexes. Given that the order is ascending, this not only is wrong because the list will shift after each removal, but at some point it can cause an IndexError. I can also see why the patches need to be grouped together, but another approach is needed.

I wrote a currently failing test that at some point tries to apply the following patches `[('add', '', [('bar', 'baz')]), ('remove', 'foo', [(1, {'y': 2})]), ('remove', 'foo', [(2, {'z': 4})]), ('remove', 'foo', [(3, {'q': 5})])]` (this case is similar to the one i encountered).

[This](https://github.com/inveniosoftware/dictdiffer/blob/master/tests/test_dictdiffer.py#L204) test suggests that  patches which remove elements of a list should be sorted in descending order by index. However, in this test the patch is slightly different: all the elements to be removed are contained within the same 'remove' patch and not distinct ones like above.

Signed-off-by: Iuliana Voinea <iulianavoinea96@gmail.com>