### PR TITLE
Ignore does not work with integers #112

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -10,13 +10,12 @@
 
 """Dictdiffer is a helper module to diff and patch dictionaries."""
 
-import sys
 from copy import deepcopy
 
 import pkg_resources
 
 from ._compat import (PY2, MutableMapping, MutableSequence, MutableSet,
-                      string_types, text_type)
+                      Iterable, string_types, text_type)
 from .utils import EPSILON, PathLimit, are_different, dot_lookup
 from .version import __version__
 
@@ -118,13 +117,15 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     if path_limit is not None and not isinstance(path_limit, PathLimit):
         path_limit = PathLimit(path_limit)
 
-    if isinstance(ignore, list):
-        ignore = {
-            tuple(value) if isinstance(value, list) else value
-            for value in ignore
-        }
+    if isinstance(ignore, Iterable):
+        def _process_ignore_value(value):
+            if isinstance(value, int):
+                return value,
+            elif isinstance(value, list):
+                return tuple(value)
+            return value
 
-    node = node or []
+        ignore = type(ignore)(_process_ignore_value(value) for value in ignore)
 
     def dotted(node, default_type=list):
         """Return dotted notation."""
@@ -134,126 +135,133 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
         else:
             return default_type(node)
 
-    dotted_node = dotted(node)
+    def _diff_recursive(_first, _second, _node=None):
+        _node = _node or []
 
-    differ = False
+        dotted_node = dotted(_node)
 
-    if isinstance(first, DICT_TYPES) and isinstance(second, DICT_TYPES):
-        # dictionaries are not hashable, we can't use sets
-        def check(key):
-            """Test if key in current node should be ignored."""
-            return ignore is None or (
-                dotted(node + [key], default_type=tuple) not in ignore and
-                tuple(node + [key]) not in ignore
-            )
+        differ = False
 
-        intersection = [k for k in first if k in second and check(k)]
-        addition = [k for k in second if k not in first and check(k)]
-        deletion = [k for k in first if k not in second and check(k)]
-
-        differ = True
-
-    elif isinstance(first, LIST_TYPES) and isinstance(second, LIST_TYPES):
-        len_first = len(first)
-        len_second = len(second)
-
-        intersection = list(range(0, min(len_first, len_second)))
-        addition = list(range(min(len_first, len_second), len_second))
-        deletion = list(reversed(range(min(len_first, len_second), len_first)))
-
-        differ = True
-
-    elif isinstance(first, SET_TYPES) and isinstance(second, SET_TYPES):
-        # Deep copy is not necessary for hashable items.
-        addition = second - first
-        if len(addition):
-            yield ADD, dotted_node, [(0, addition)]
-        deletion = first - second
-        if len(deletion):
-            yield REMOVE, dotted_node, [(0, deletion)]
-
-    if differ:
-        # Compare if object is a dictionary or list.
-        #
-        # NOTE variables: intersection, addition, deletion contain only
-        # hashable types, hence they do not need to be deepcopied.
-        #
-        # Call again the parent function as recursive if dictionary have child
-        # objects.  Yields `add` and `remove` flags.
-        for key in intersection:
-            # if type is not changed, callees again diff function to compare.
-            # otherwise, the change will be handled as `change` flag.
-            if path_limit and path_limit.path_is_limit(node+[key]):
-                yield CHANGE, node+[key], (
-                    deepcopy(first[key]), deepcopy(second[key])
+        if isinstance(_first, DICT_TYPES) and isinstance(_second, DICT_TYPES):
+            # dictionaries are not hashable, we can't use sets
+            def check(key):
+                """Test if key in current node should be ignored."""
+                return ignore is None or (
+                    dotted(_node + [key],
+                           default_type=tuple) not in ignore and
+                    tuple(_node + [key]) not in ignore
                 )
-            else:
-                recurred = diff(first[key],
-                                second[key],
-                                node=node + [key],
-                                ignore=ignore,
-                                path_limit=path_limit,
-                                expand=expand,
-                                tolerance=tolerance)
 
-                for diffed in recurred:
-                    yield diffed
+            intersection = [k for k in _first if k in _second and check(k)]
+            addition = [k for k in _second if k not in _first and check(k)]
+            deletion = [k for k in _first if k not in _second and check(k)]
 
-        if addition:
-            if path_limit:
-                collect = []
-                collect_recurred = []
-                for key in addition:
-                    if not isinstance(second[key],
-                                      SET_TYPES + LIST_TYPES + DICT_TYPES):
-                        collect.append((key, deepcopy(second[key])))
-                    elif path_limit.path_is_limit(node+[key]):
-                        collect.append((key, deepcopy(second[key])))
-                    else:
-                        collect.append((key, second[key].__class__()))
-                        recurred = diff(second[key].__class__(),
-                                        second[key],
-                                        node=node+[key],
-                                        ignore=ignore,
-                                        path_limit=path_limit,
-                                        expand=expand,
-                                        tolerance=tolerance)
+            differ = True
 
-                        collect_recurred.append(recurred)
+        elif isinstance(_first, LIST_TYPES) and isinstance(_second,
+                                                           LIST_TYPES):
+            len_first = len(_first)
+            len_second = len(_second)
 
-                if expand:
-                    for key, val in collect:
-                        yield ADD, dotted_node, [(key, val)]
+            intersection = list(range(0, min(len_first, len_second)))
+            addition = list(range(min(len_first, len_second), len_second))
+            deletion = list(
+                reversed(range(min(len_first, len_second), len_first)))
+
+            differ = True
+
+        elif isinstance(_first, SET_TYPES) and isinstance(_second, SET_TYPES):
+            # Deep copy is not necessary for hashable items.
+            addition = _second - _first
+            if len(addition):
+                yield ADD, dotted_node, [(0, addition)]
+            deletion = _first - _second
+            if len(deletion):
+                yield REMOVE, dotted_node, [(0, deletion)]
+
+        if differ:
+            # Compare if object is a dictionary or list.
+            #
+            # NOTE variables: intersection, addition, deletion contain only
+            # hashable types, hence they do not need to be deepcopied.
+            #
+            # Call again the parent function as recursive if dictionary have
+            # child objects.  Yields `add` and `remove` flags.
+            for key in intersection:
+                # if type is not changed,
+                # callees again diff function to compare.
+                # otherwise, the change will be handled as `change` flag.
+                if path_limit and path_limit.path_is_limit(_node + [key]):
+                    yield CHANGE, _node + [key], (
+                        deepcopy(_first[key]), deepcopy(_second[key])
+                    )
                 else:
-                    yield ADD, dotted_node, collect
+                    recurred = _diff_recursive(
+                        _first[key], _second[key],
+                        _node=_node + [key],
+                    )
 
-                for recurred in collect_recurred:
                     for diffed in recurred:
                         yield diffed
-            else:
-                if expand:
+
+            if addition:
+                if path_limit:
+                    collect = []
+                    collect_recurred = []
                     for key in addition:
-                        yield ADD, dotted_node, [(key, deepcopy(second[key]))]
+                        if not isinstance(_second[key],
+                                          SET_TYPES + LIST_TYPES + DICT_TYPES):
+                            collect.append((key, deepcopy(_second[key])))
+                        elif path_limit.path_is_limit(_node + [key]):
+                            collect.append((key, deepcopy(_second[key])))
+                        else:
+                            collect.append((key, _second[key].__class__()))
+                            recurred = _diff_recursive(
+                                _second[key].__class__(),
+                                _second[key],
+                                _node=_node + [key],
+                            )
+
+                            collect_recurred.append(recurred)
+
+                    if expand:
+                        for key, val in collect:
+                            yield ADD, dotted_node, [(key, val)]
+                    else:
+                        yield ADD, dotted_node, collect
+
+                    for recurred in collect_recurred:
+                        for diffed in recurred:
+                            yield diffed
                 else:
-                    yield ADD, dotted_node, [
-                        # for additions, return a list that consist with
-                        # two-pair tuples.
-                        (key, deepcopy(second[key])) for key in addition]
+                    if expand:
+                        for key in addition:
+                            yield ADD, dotted_node, [
+                                (key, deepcopy(_second[key]))]
+                    else:
+                        yield ADD, dotted_node, [
+                            # for additions, return a list that consist with
+                            # two-pair tuples.
+                            (key, deepcopy(_second[key])) for key in addition]
 
-        if deletion:
-            if expand:
-                for key in deletion:
-                    yield REMOVE, dotted_node, [(key, deepcopy(first[key]))]
-            else:
-                yield REMOVE, dotted_node, [
-                    # for deletions, return the list of removed keys
-                    # and values.
-                    (key, deepcopy(first[key])) for key in deletion]
+            if deletion:
+                if expand:
+                    for key in deletion:
+                        yield REMOVE, dotted_node, [
+                            (key, deepcopy(_first[key]))]
+                else:
+                    yield REMOVE, dotted_node, [
+                        # for deletions, return the list of removed keys
+                        # and values.
+                        (key, deepcopy(_first[key])) for key in deletion]
 
-    else:
-        # Compare string and numerical types and yield `change` flag.
-        if are_different(first, second, tolerance):
-            yield CHANGE, dotted_node, (deepcopy(first), deepcopy(second))
+        else:
+            # Compare string and numerical types and yield `change` flag.
+            if are_different(_first, _second, tolerance):
+                yield CHANGE, dotted_node, (deepcopy(_first),
+                                            deepcopy(_second))
+
+    return _diff_recursive(first, second, node)
 
 
 def patch(diff_result, destination, in_place=False):

--- a/dictdiffer/_compat.py
+++ b/dictdiffer/_compat.py
@@ -20,10 +20,12 @@ except NameError:
     num_types = int, float
 
 if PY2:
-    from collections import MutableMapping, MutableSet, MutableSequence
+    from collections import (
+        MutableMapping, MutableSet, MutableSequence, Iterable)
     from itertools import izip_longest as _zip_longest
 else:
-    from collections.abc import MutableMapping, MutableSet, MutableSequence
+    from collections.abc import (
+        MutableMapping, MutableSet, MutableSequence, Iterable)
     from itertools import zip_longest as _zip_longest
 
 izip_longest = _zip_longest

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'tox>=3.7.0',
 ]
 
 extras_require = {

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -208,8 +208,8 @@ class DictDifferTests(unittest.TestCase):
         assert ('remove', 'a', [(1, 'c'), (0, 'b'), ]) == diffed
 
     def test_add_set(self):
-        first = {'a': set([1, 2, 3])}
-        second = {'a': set([0, 1, 2, 3])}
+        first = {'a': {1, 2, 3}}
+        second = {'a': {0, 1, 2, 3}}
         diffed = next(diff(first, second))
         assert ('add', 'a', [(0, set([0]))]) == diffed
 
@@ -300,6 +300,26 @@ class DictDifferTests(unittest.TestCase):
         assert ('change', ['a', 1, 'a'], ('a', 1)) == diffed
         diffed = next(diff(second, first, ignore=[['a', 1, 'b']]))
         assert ('change', ['a', 1, 'a'], (1, 'a')) == diffed
+
+    def test_ignore_stringofintegers_keys(self):
+        a = {'1': '1', '2': '2', '3': '3'}
+        b = {'1': '1', '2': '2', '3': '99', '4': '100'}
+
+        assert list(diff(a, b, ignore={'3', '4'})) == []
+
+    def test_ignore_integers_keys(self):
+        a = {1: 1, 2: 2, 3: 3}
+        b = {1: 1, 2: 2, 3: 99, 4: 100}
+
+        assert len(list(diff(a, b, ignore={3, 4}))) == 0
+
+    def test_ignore_with_ignorecase(self):
+        class IgnoreCase(set):
+            def __contains__(self, key):
+                return set.__contains__(self, str(key).lower())
+
+        assert list(diff({'a': 1, 'b': 2}, {'A': 3, 'b': 4},
+                         ignore=IgnoreCase('a'))) == [('change', 'b', (2, 4))]
 
     def test_complex_diff(self):
         """Check regression on issue #4."""


### PR DESCRIPTION
PR for this issue: [Ignore does not work with integers #112](https://github.com/inveniosoftware/dictdiffer/issues/112)

```
(py3_dictdiffer) ➜  dictdiffer git:(master) ./run-tests.sh
Skipped 1 files
lists of files in version control and sdist match
running pytest
running egg_info
writing dictdiffer.egg-info/PKG-INFO
writing dependency_links to dictdiffer.egg-info/dependency_links.txt
writing requirements to dictdiffer.egg-info/requires.txt
writing top-level names to dictdiffer.egg-info/top_level.txt
reading manifest file 'dictdiffer.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'dictdiffer.egg-info/SOURCES.txt'
running build_ext
======================================================================= test session starts =======================================================================
platform linux -- Python 3.6.8, pytest-4.2.0, py-1.7.0, pluggy-0.8.1
rootdir: /home/.../dictdiffer, inifile: pytest.ini
plugins: pep8-1.0.6, cov-2.6.1
collected 101 items

tests/test_conflict.py .....                                                                                                                                [  4%]
tests/test_dictdiffer.py ...................................................                                                                                [ 55%]
tests/test_merge.py ....                                                                                                                                    [ 59%]
tests/test_resolve.py .........                                                                                                                             [ 68%]
tests/test_unify.py ...                                                                                                                                     [ 71%]
tests/test_utils.py ........                                                                                                                                [ 79%]
dictdiffer/__init__.py ....                                                                                                                                 [ 83%]
dictdiffer/_compat.py .                                                                                                                                     [ 84%]
dictdiffer/conflict.py .                                                                                                                                    [ 85%]
dictdiffer/merge.py ..                                                                                                                                      [ 87%]
dictdiffer/resolve.py ..                                                                                                                                    [ 89%]
dictdiffer/unify.py .                                                                                                                                       [ 90%]
dictdiffer/utils.py .........                                                                                                                               [ 99%]
dictdiffer/version.py .                                                                                                                                     [100%]

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
dictdiffer/__init__.py     130      0   100%
dictdiffer/_compat.py       17      4    76%   14-15, 23-24
dictdiffer/conflict.py      28      0   100%
dictdiffer/merge.py         42      0   100%
dictdiffer/resolve.py       51      0   100%
dictdiffer/unify.py         19      0   100%
dictdiffer/utils.py        107      0   100%
dictdiffer/version.py        2      0   100%
------------------------------------------------------
TOTAL                      396      4    99%


=================================================================== 101 passed in 1.23 seconds ====================================================================
```