### PR TITLE
diff: support diff of numpy NaN and float('NaN')

### DIFF
--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -1,7 +1,7 @@
 # This file is part of Dictdiffer.
 #
 # Copyright (C) 2015 CERN.
-# Copyright (C) 2017 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
+# Copyright (C) 2017, 2019 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -262,12 +262,14 @@ def are_different(first, second, tolerance):
     if first == second:
         # values are same - simple case
         return False
-    elif bool(first != first) ^ bool(second != second):
-        # only one of them is 'NaN', hence they are different
-        return True
+
+    first_is_nan, second_is_nan = bool(first != first), bool(second != second)
+
+    if first_is_nan or second_is_nan:
+        # two 'NaN' values are not different (see issue #114)
+        return not (first_is_nan and second_is_nan)
     elif isinstance(first, num_types) and isinstance(second, num_types):
-        # (a) two numerical values are compared with tolerance
-        # (b) both values are NaN and they will never fit the tolerance
+        # two numerical values are compared with tolerance
         return abs(first-second) > tolerance * max(abs(first), abs(second))
     # we got different values
     return True

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2013 Fatih Erikli.
 # Copyright (C) 2013, 2014, 2015, 2016 CERN.
-# Copyright (C) 2017, 2018 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
+# Copyright (C) 2017-2019 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -239,6 +239,15 @@ class DictDifferTests(unittest.TestCase):
 
         diffed = list(diff([value], [3.5]))
         assert [('change', [0], (value, 3.5))] == diffed
+
+    @unittest.skipIf(not HAS_NUMPY, 'NumPy is not installed')
+    def test_numpy_nan(self):
+        """Compare NumPy NaNs (#114)."""
+        import numpy as np
+        first = {'a': np.float32('nan')}
+        second = {'a': float('nan')}
+        result = list(diff(first, second))
+        assert result == []
 
     def test_unicode_keys(self):
         first = {u'привет': 1}


### PR DESCRIPTION
* BETTER Two NaN values are considered the same, hence they are not
  shown in `diff` output.  (closes #114)

--
cc @t-b