### PR TITLE
Wrong diff in case of dictionary has dotted keys in ignore in dictdiffer.

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2013 Fatih Erikli.
 # Copyright (C) 2013, 2014, 2015, 2016 CERN.
-# Copyright (C) 2017, 2018 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
+# Copyright (C) 2017-2019 ETH Zurich, Swiss Data Science Center, Jiri Kuncar.
 #
 # Dictdiffer is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more
@@ -16,8 +16,7 @@ import pkg_resources
 
 from ._compat import (PY2, Iterable, MutableMapping, MutableSequence,
                       MutableSet, string_types, text_type)
-from .utils import (EPSILON, DottedIgnoreKey, PathLimit, are_different,
-                    dot_lookup)
+from .utils import EPSILON, PathLimit, are_different, dot_lookup
 from .version import __version__
 
 (ADD, REMOVE, CHANGE) = (
@@ -135,8 +134,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 return value,
             elif isinstance(value, list):
                 return tuple(value)
-            elif isinstance(value, DottedIgnoreKey):
-                return str(value),
+            elif not dot_notation and isinstance(value, str):
+                return value,
             return value
 
         ignore = type(ignore)(_process_ignore_value(value) for value in ignore)

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -16,8 +16,8 @@ import pkg_resources
 
 from ._compat import (PY2, Iterable, MutableMapping, MutableSequence,
                       MutableSet, string_types, text_type)
-from .utils import (EPSILON, PathLimit, are_different, dot_lookup,
-                    DottedIgnoreKey)
+from .utils import (EPSILON, DottedIgnoreKey, PathLimit, are_different,
+                    dot_lookup)
 from .version import __version__
 
 (ADD, REMOVE, CHANGE) = (

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -16,7 +16,8 @@ import pkg_resources
 
 from ._compat import (PY2, Iterable, MutableMapping, MutableSequence,
                       MutableSet, string_types, text_type)
-from .utils import EPSILON, PathLimit, are_different, dot_lookup
+from .utils import (EPSILON, PathLimit, are_different, dot_lookup,
+                    DottedIgnoreKey)
 from .version import __version__
 
 (ADD, REMOVE, CHANGE) = (
@@ -134,6 +135,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 return value,
             elif isinstance(value, list):
                 return tuple(value)
+            elif isinstance(value, DottedIgnoreKey):
+                return str(value),
             return value
 
         ignore = type(ignore)(_process_ignore_value(value) for value in ignore)

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -159,8 +159,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
             def check(key):
                 """Test if key in current node should be ignored."""
                 return ignore is None or (
-                    dotted(_node + [key],
-                           default_type=tuple) not in ignore and
+                    dotted(_node + [key], default_type=tuple) not in ignore and
                     tuple(_node + [key]) not in ignore
                 )
 

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -134,7 +134,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                 return value,
             elif isinstance(value, list):
                 return tuple(value)
-            elif not dot_notation and isinstance(value, str):
+            elif not dot_notation and isinstance(value, string_types):
                 return value,
             return value
 

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -16,6 +16,15 @@ from ._compat import izip_longest, num_types, string_types
 EPSILON = sys.float_info.epsilon
 
 
+class DottedIgnoreKey(str):
+    """Custom type to specify dotted ignore key.
+
+    This custom type help to desactivate dotted interpretation.
+    """
+
+    pass
+
+
 class WildcardDict(dict):
     """Provide possibility to use special wildcard keys to access values.
 

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -22,8 +22,6 @@ class DottedIgnoreKey(str):
     This custom type help to desactivate dotted interpretation.
     """
 
-    pass
-
 
 class WildcardDict(dict):
     """Provide possibility to use special wildcard keys to access values.

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -16,13 +16,6 @@ from ._compat import izip_longest, num_types, string_types
 EPSILON = sys.float_info.epsilon
 
 
-class DottedIgnoreKey(str):
-    """Custom type to specify dotted ignore key.
-
-    This custom type help to desactivate dotted interpretation.
-    """
-
-
 class WildcardDict(dict):
     """Provide possibility to use special wildcard keys to access values.
 

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -13,9 +13,11 @@
 import unittest
 from collections import OrderedDict
 
+import pytest
+
 from dictdiffer import HAS_NUMPY, diff, dot_lookup, patch, revert, swap
 from dictdiffer._compat import MutableMapping, MutableSequence, MutableSet
-from dictdiffer.utils import DottedIgnoreKey, PathLimit
+from dictdiffer.utils import PathLimit
 
 
 class DictDifferTests(unittest.TestCase):
@@ -290,26 +292,6 @@ class DictDifferTests(unittest.TestCase):
         second = {'a': {'aa': 1, 'ab': 'B', 'ac': 3}}
         diffed = next(diff(first, second, ignore=['a.aa']))
         assert ('change', 'a.ac', ('C', 3)) == diffed
-
-    def test_ignore_dotted_ignore_key(self):
-        key_to_ignore = u'nifi.zookeeper.session.timeout'
-        config_dict = OrderedDict(
-            [('address', 'devops011-slv-01.gvs.ggn'),
-             (key_to_ignore, '3 secs')])
-
-        ref_dict = OrderedDict(
-            [('address', 'devops011-slv-01.gvs.ggn'),
-             (key_to_ignore, '4 secs')])
-
-        assert len(
-            list(diff(config_dict, ref_dict,
-                      dot_notation=True,
-                      ignore=[DottedIgnoreKey(key_to_ignore)]))) == 0
-
-        assert len(
-            list(diff(config_dict, ref_dict,
-                      dot_notation=False,
-                      ignore=[DottedIgnoreKey(key_to_ignore)]))) == 0
 
     def test_ignore_with_unicode_sub_keys(self):
         first = {u'a': {u'aא': {u'aa': 'A'}}}
@@ -683,6 +665,30 @@ class DotLookupTest(unittest.TestCase):
 
     def test_invalit_lookup_type(self):
         self.assertRaises(TypeError, dot_lookup, {0: '0'}, 0)
+
+
+@pytest.mark.parametrize(
+    'ignore,dot_notation,diff_size', [
+        (u'nifi.zookeeper.session.timeout', True, 1),
+        (u'nifi.zookeeper.session.timeout', False, 0),
+        ((u'nifi.zookeeper.session.timeout', ), True, 0),
+        ((u'nifi.zookeeper.session.timeout', ), False, 0),
+    ],
+)
+def test_ignore_dotted_ignore_key(ignore, dot_notation, diff_size):
+    key_to_ignore = u'nifi.zookeeper.session.timeout'
+    config_dict = OrderedDict(
+        [('address', 'devops011-slv-01.gvs.ggn'),
+            (key_to_ignore, '3 secs')])
+
+    ref_dict = OrderedDict(
+        [('address', 'devops011-slv-01.gvs.ggn'),
+            (key_to_ignore, '4 secs')])
+
+    assert diff_size == len(
+        list(diff(config_dict, ref_dict,
+                  dot_notation=dot_notation,
+                  ignore=[ignore])))
 
 
 if __name__ == "__main__":

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -303,6 +303,12 @@ class DictDifferTests(unittest.TestCase):
 
         assert len(
             list(diff(config_dict, ref_dict,
+                      dot_notation=True,
+                      ignore=[DottedIgnoreKey(key_to_ignore)]))) == 0
+
+        assert len(
+            list(diff(config_dict, ref_dict,
+                      dot_notation=False,
                       ignore=[DottedIgnoreKey(key_to_ignore)]))) == 0
 
     def test_ignore_with_unicode_sub_keys(self):

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -10,12 +10,12 @@
 # it under the terms of the MIT License; see LICENSE file for more
 # details.
 
-from collections import OrderedDict
 import unittest
+from collections import OrderedDict
 
 from dictdiffer import HAS_NUMPY, diff, dot_lookup, patch, revert, swap
 from dictdiffer._compat import MutableMapping, MutableSequence, MutableSet
-from dictdiffer.utils import PathLimit
+from dictdiffer.utils import DottedIgnoreKey, PathLimit
 
 
 class DictDifferTests(unittest.TestCase):
@@ -291,16 +291,19 @@ class DictDifferTests(unittest.TestCase):
         diffed = next(diff(first, second, ignore=['a.aa']))
         assert ('change', 'a.ac', ('C', 3)) == diffed
 
+    def test_ignore_dotted_ignore_key(self):
+        key_to_ignore = u'nifi.zookeeper.session.timeout'
         config_dict = OrderedDict(
             [('address', 'devops011-slv-01.gvs.ggn'),
-             ('nifi.zookeeper.session.timeout', '3 secs')])
+             (key_to_ignore, '3 secs')])
 
         ref_dict = OrderedDict(
             [('address', 'devops011-slv-01.gvs.ggn'),
-             ('nifi.zookeeper.session.timeout', '4 secs')])
+             (key_to_ignore, '4 secs')])
 
-        assert [] == list(diff(config_dict, ref_dict,
-                               ignore={'nifi.zookeeper.session.timeout'}))
+        assert len(
+            list(diff(config_dict, ref_dict,
+                      ignore=[DottedIgnoreKey(key_to_ignore)]))) == 0
 
     def test_ignore_with_unicode_sub_keys(self):
         first = {u'a': {u'aא': {u'aa': 'A'}}}

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -10,6 +10,7 @@
 # it under the terms of the MIT License; see LICENSE file for more
 # details.
 
+from collections import OrderedDict
 import unittest
 
 from dictdiffer import HAS_NUMPY, diff, dot_lookup, patch, revert, swap
@@ -289,6 +290,17 @@ class DictDifferTests(unittest.TestCase):
         second = {'a': {'aa': 1, 'ab': 'B', 'ac': 3}}
         diffed = next(diff(first, second, ignore=['a.aa']))
         assert ('change', 'a.ac', ('C', 3)) == diffed
+
+        config_dict = OrderedDict(
+            [('address', 'devops011-slv-01.gvs.ggn'),
+             ('nifi.zookeeper.session.timeout', '3 secs')])
+
+        ref_dict = OrderedDict(
+            [('address', 'devops011-slv-01.gvs.ggn'),
+             ('nifi.zookeeper.session.timeout', '4 secs')])
+
+        assert [] == list(diff(config_dict, ref_dict,
+                               ignore={'nifi.zookeeper.session.timeout'}))
 
     def test_ignore_with_unicode_sub_keys(self):
         first = {u'a': {u'aא': {u'aa': 'A'}}}


### PR DESCRIPTION
Resolve issue #107.

Use a custom type `DottedIgnoreKey` to deactivate interpretation (interpolation) of keys (with dot inside).
Add unit-tests to check the correctness/fix.