### PR TITLE
diff: argument for toggling dot notation

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -90,6 +90,18 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}, expand=True))
     [('add', 'fruits', [(0, 'apple')]), ('add', 'fruits', [(1, 'mango')])]
 
+    >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}, expand=True))
+    [('add', 'fruits', [(0, 'apple')]), ('add', 'fruits', [(1, 'mango')])]
+
+    >>> list(diff({'a': {'x': 1, 'y': [{'z': 3}]}},
+    ... {'a': {'x': 2, 'y': [{'z': 4}]}}))
+    [('change', 'a.x', (1, 2)), ('change', ['a', 'y', 0, 'z'], (3, 4))]
+
+    >>> list(diff({'a': {'x': 1, 'y': [{'z': 3}]}},
+    ... {'a': {'x': 2, 'y': [{'z': 4}]}},
+    ... dot_notation=False))
+    [('change', ['a', 'x'], (1, 2)), ('change', ['a', 'y', 0, 'z'], (3, 4))]
+
     :param first: The original dictionary, ``list`` or ``set``.
     :param second: New dictionary, ``list`` or ``set``.
     :param node: Key for comparison that can be used in :func:`dot_lookup`.

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -130,7 +130,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     def dotted(node, default_type=list):
         """Return dotted notation."""
         if dot_notation and \
-        all(map(lambda x: isinstance(x, string_types) and '.' not in x, node)):
+            all(map(lambda x: isinstance(x, string_types) and '.' not in x,
+                node)):
             return '.'.join(node)
         else:
             return default_type(node)

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -90,17 +90,12 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}, expand=True))
     [('add', 'fruits', [(0, 'apple')]), ('add', 'fruits', [(1, 'mango')])]
 
-    >>> list(diff({'fruits': []}, {'fruits': ['apple', 'mango']}, expand=True))
-    [('add', 'fruits', [(0, 'apple')]), ('add', 'fruits', [(1, 'mango')])]
+    >>> list(diff({'a': {'x': 1}}, {'a': {'x': 2}}))
+    [('change', 'a.x', (1, 2))]
 
-    >>> list(diff({'a': {'x': 1, 'y': [{'z': 3}]}},
-    ... {'a': {'x': 2, 'y': [{'z': 4}]}}))
-    [('change', 'a.x', (1, 2)), ('change', ['a', 'y', 0, 'z'], (3, 4))]
-
-    >>> list(diff({'a': {'x': 1, 'y': [{'z': 3}]}},
-    ... {'a': {'x': 2, 'y': [{'z': 4}]}},
+    >>> list(diff({'a': {'x': 1}}, {'a': {'x': 2}},
     ... dot_notation=False))
-    [('change', ['a', 'x'], (1, 2)), ('change', ['a', 'y', 0, 'z'], (3, 4))]
+    [('change', ['a', 'x'], (1, 2))]
 
     :param first: The original dictionary, ``list`` or ``set``.
     :param second: New dictionary, ``list`` or ``set``.

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -41,7 +41,7 @@ else:
 
 
 def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
-         tolerance=EPSILON):
+         tolerance=EPSILON, dot_notation=True):
     """Compare two dictionary/list/set objects, and returns a diff result.
 
     Return an iterator with differences between two objects. The diff items
@@ -129,7 +129,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
 
     def dotted(node, default_type=list):
         """Return dotted notation."""
-        if all(map(lambda x: isinstance(x, string_types) and '.' not in x,
+        if dot_notation and all(map(lambda x: isinstance(x, string_types) and '.' not in x,
                    node)):
             return '.'.join(node)
         else:

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -121,6 +121,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     .. versionchanged:: 0.7
        Diff items are deep copies from its corresponding objects.
        Argument *ignore* is always converted to a ``set``.
+
     .. versionchanged:: 0.8
         Added *dot_notation* parameter.
     """

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -110,6 +110,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                        object to limit the diff recursion depth.
     :param expand: Expand the patches.
     :param tolerance: Threshold to consider when comparing two float numbers.
+    :param dot_notation: Boolean to toggle dot notation on and off.
 
     .. versionchanged:: 0.3
        Added *ignore* parameter.
@@ -125,6 +126,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     .. versionchanged:: 0.7
        Diff items are deep copies from its corresponding objects.
        Argument *ignore* is always converted to a ``set``.
+    .. versionchanged:: 0.8
+        Added *dot_notation* parameter.
     """
     if path_limit is not None and not isinstance(path_limit, PathLimit):
         path_limit = PathLimit(path_limit)

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -129,8 +129,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
 
     def dotted(node, default_type=list):
         """Return dotted notation."""
-        if dot_notation and all(map(lambda x: isinstance(x, string_types) and '.' not in x,
-                   node)):
+        if dot_notation and \
+        all(map(lambda x: isinstance(x, string_types) and '.' not in x, node)):
             return '.'.join(node)
         else:
             return default_type(node)

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -19,19 +19,17 @@ from dictdiffer.utils import PathLimit
 
 class DictDifferTests(unittest.TestCase):
     def test_without_dot_notation(self):
-        change1, change2 = diff({'a': {'x': 1, 'y': [{'z': 3}]}},
-                                {'a': {'x': 2, 'y': [{'z': 4}]}},
-                                dot_notation=False)
+        (change1,) = diff({'a': {'x': 1}},
+                          {'a': {'x': 2}},
+                          dot_notation=False)
 
         assert change1 == ('change', ['a', 'x'], (1, 2))
-        assert change2 == ('change', ['a', 'y', 0, 'z'], (3, 4))
 
     def test_with_dot_notation(self):
-        change1, change2 = diff({'a': {'x': 1, 'y': [{'z': 3}]}},
-                                {'a': {'x': 2, 'y': [{'z': 4}]}})
+        (change1,) = diff({'a': {'x': 1}},
+                          {'a': {'x': 2}})
 
         assert change1 == ('change', 'a.x', (1, 2))
-        assert change2 == ('change', ['a', 'y', 0, 'z'], (3, 4))
 
     def test_addition(self):
         first = {}

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -18,6 +18,21 @@ from dictdiffer.utils import PathLimit
 
 
 class DictDifferTests(unittest.TestCase):
+    def test_without_dot_notation(self):
+        change1, change2 = diff({'a': {'x': 1, 'y': [{'z': 3}]}},
+                                {'a': {'x': 2, 'y': [{'z': 4}]}},
+                                dot_notation=False)
+
+        assert change1 == ('change', ['a', 'x'], (1, 2))
+        assert change2 == ('change', ['a', 'y', 0, 'z'], (3, 4))
+
+    def test_with_dot_notation(self):
+        change1, change2 = diff({'a': {'x': 1, 'y': [{'z': 3}]}},
+                                {'a': {'x': 2, 'y': [{'z': 4}]}})
+
+        assert change1 == ('change', 'a.x', (1, 2))
+        assert change2 == ('change', ['a', 'y', 0, 'z'], (3, 4))
+
     def test_addition(self):
         first = {}
         second = {'a': 'b'}


### PR DESCRIPTION
I need to do further processing on the returned diff, so having to handle both dot and list notations is a hassle.

**Example**
```
(   ('change', ['db_suburb', 'title', 'args', 0, 'args', 0], (60, 601)),
    (   'change',
        ['db_suburb', 'title', 'args', 0, 'sql'],
        ('VARCHAR(60)', 'VARCHAR(601)')),
    (   'change',
        'db_suburb.title.sql',
        ('VARCHAR(60) NOT NULL', 'VARCHAR(601) NOT NULL')))
```
Trying to extract the 3 occurences `db_suburb` in the above diff is a pain.
```
changes = (   ('change', ['db_suburb', 'title', 'args', 0, 'args', 0], (60, 601)),
    (   'change',
        ['db_suburb', 'title', 'args', 0, 'sql'],
        ('VARCHAR(60)', 'VARCHAR(601)')),
    (   'change',
        ['db_suburb', 'title', 'sql'],
        ('VARCHAR(60) NOT NULL', 'VARCHAR(601) NOT NULL')))
```
Whereas above can be done so quite easily with:
```
collect = []
for change in changes:
  action, [table_name, *rest] = change
  collect.append(table_name)
```