### PR TITLE
diff: add support for absolute tolerance of floats

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -35,7 +35,7 @@ except ImportError:  # pragma: no cover
 
 
 def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
-         tolerance=EPSILON, dot_notation=True):
+         tolerance=EPSILON, absolute_tolerance=None, dot_notation=True):
     """Compare two dictionary/list/set objects, and returns a diff result.
 
     Return an iterator with differences between two objects. The diff items
@@ -99,6 +99,8 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
                        object to limit the diff recursion depth.
     :param expand: Expand the patches.
     :param tolerance: Threshold to consider when comparing two float numbers.
+    :param absolute_tolerance: Absolute threshold to consider when comparing
+                               two float numbers.
     :param dot_notation: Boolean to toggle dot notation on and off.
 
     .. versionchanged:: 0.3
@@ -266,7 +268,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
 
         else:
             # Compare string and numerical types and yield `change` flag.
-            if are_different(_first, _second, tolerance):
+            if are_different(_first, _second, tolerance, absolute_tolerance):
                 yield CHANGE, dotted_node, (deepcopy(_first),
                                             deepcopy(_second))
 

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -9,6 +9,7 @@
 
 """Utils gathers helper functions, classes for the dictdiffer module."""
 
+import math
 import sys
 from itertools import zip_longest
 
@@ -270,17 +271,11 @@ def are_different(first, second, tolerance, absolute_tolerance):
         return not (first_is_nan and second_is_nan)
     elif isinstance(first, num_types) and isinstance(second, num_types):
         # two numerical values are compared with tolerance
-        if tolerance is not None:
-            rel_diff = (
-                abs(first-second) > tolerance * max(abs(first), abs(second))
-            )
-        else:
-            rel_diff = True
-        # two numerical values are compared with absolute_tolerance
-        if absolute_tolerance is not None:
-            abs_diff = (abs(first-second) > absolute_tolerance)
-        else:
-            abs_diff = True
-        return rel_diff and abs_diff
+        return not math.isclose(
+            first,
+            second,
+            rel_tol=tolerance or 0,
+            abs_tol=absolute_tolerance or 0,
+        )
     # we got different values
     return True

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -253,7 +253,7 @@ def dot_lookup(source, lookup, parent=False):
     return value
 
 
-def are_different(first, second, tolerance, absolute_tolerance):
+def are_different(first, second, tolerance, absolute_tolerance=None):
     """Check if 2 values are different.
 
     In case of numerical values, the tolerance is used to check if the values

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -252,7 +252,7 @@ def dot_lookup(source, lookup, parent=False):
     return value
 
 
-def are_different(first, second, tolerance):
+def are_different(first, second, tolerance, absolute_tolerance):
     """Check if 2 values are different.
 
     In case of numerical values, the tolerance is used to check if the values
@@ -270,6 +270,17 @@ def are_different(first, second, tolerance):
         return not (first_is_nan and second_is_nan)
     elif isinstance(first, num_types) and isinstance(second, num_types):
         # two numerical values are compared with tolerance
-        return abs(first-second) > tolerance * max(abs(first), abs(second))
+        if tolerance is not None:
+            rel_diff = (
+                abs(first-second) > tolerance * max(abs(first), abs(second))
+            )
+        else:
+            rel_diff = True
+        # two numerical values are compared with absolute_tolerance
+        if absolute_tolerance is not None:
+            abs_diff = (abs(first-second) > absolute_tolerance)
+        else:
+            abs_diff = True
+        return rel_diff and abs_diff
     # we got different values
     return True

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.8.2.dev2+dirty'
+__version__ = '0.8.2.dev4+dirty'

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.8.2.dev4+dirty'
+__version__ = '0.8.2.dev5+dirty'

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.8.2.dev5+dirty'
+__version__ = '0.8.2.dev10+dirty'

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -103,6 +103,54 @@ class DictDifferTests(unittest.TestCase):
         diffed = next(diff(first, second, tolerance=0.01))
         assert ('change', 'a', (10.0, 10.5)) == diffed
 
+        first = {'a': 10.0, 'b': 1.0e-15}
+        second = {'a': 10.5, 'b': 2.5e-15}
+        diffed = list(diff(
+            first, second, tolerance=0.01
+        ))
+        assert [
+            ('change', 'a', (10.0, 10.5)),
+            ('change', 'b', (1.0e-15, 2.5e-15)),
+        ] == diffed
+
+        diffed = list(diff(
+            first, second, tolerance=0.01, absolute_tolerance=1e-12
+        ))
+        assert [('change', 'a', (10.0, 10.5))] == diffed
+
+        diffed = list(diff(
+            first, second, tolerance=0.01, absolute_tolerance=1e-18
+        ))
+        assert [
+            ('change', 'a', (10.0, 10.5)),
+            ('change', 'b', (1.0e-15, 2.5e-15)),
+        ] == diffed
+
+        diffed = list(diff(
+            first, second, tolerance=0.1, absolute_tolerance=1e-18
+        ))
+        assert [('change', 'b', (1.0e-15, 2.5e-15))] == diffed
+
+        diffed = list(diff(
+            first, second, tolerance=0.1, absolute_tolerance=1e-12
+        ))
+        assert [] == diffed
+
+        diffed = list(diff(
+            first, second, tolerance=None, absolute_tolerance=None
+        ))
+        assert [
+            ('change', 'a', (10.0, 10.5)),
+            ('change', 'b', (1.0e-15, 2.5e-15)),
+        ] == diffed
+
+        first = {'a': 10.0, 'b': 1.0e-15}
+        second = {'a': 10.0, 'b': 1.0e-15}
+        diffed = list(diff(
+            first, second, tolerance=None, absolute_tolerance=None
+        ))
+        assert [] == diffed
+
     def test_path_limit_as_list(self):
         first = {}
         second = {'author': {'last_name': 'Doe', 'first_name': 'John'}}

--- a/tests/test_dictdiffer.py
+++ b/tests/test_dictdiffer.py
@@ -11,7 +11,8 @@
 # details.
 
 import unittest
-from collections import MutableMapping, MutableSequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping, MutableSequence
 
 import pytest
 
@@ -105,7 +106,7 @@ class DictDifferTests(unittest.TestCase):
 
         first = {'a': 10.0, 'b': 1.0e-15}
         second = {'a': 10.5, 'b': 2.5e-15}
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=0.01
         ))
         assert [
@@ -113,12 +114,12 @@ class DictDifferTests(unittest.TestCase):
             ('change', 'b', (1.0e-15, 2.5e-15)),
         ] == diffed
 
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=0.01, absolute_tolerance=1e-12
         ))
         assert [('change', 'a', (10.0, 10.5))] == diffed
 
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=0.01, absolute_tolerance=1e-18
         ))
         assert [
@@ -126,17 +127,17 @@ class DictDifferTests(unittest.TestCase):
             ('change', 'b', (1.0e-15, 2.5e-15)),
         ] == diffed
 
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=0.1, absolute_tolerance=1e-18
         ))
         assert [('change', 'b', (1.0e-15, 2.5e-15))] == diffed
 
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=0.1, absolute_tolerance=1e-12
         ))
         assert [] == diffed
 
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=None, absolute_tolerance=None
         ))
         assert [
@@ -146,7 +147,7 @@ class DictDifferTests(unittest.TestCase):
 
         first = {'a': 10.0, 'b': 1.0e-15}
         second = {'a': 10.0, 'b': 1.0e-15}
-        diffed = list(diff(
+        diffed = sorted(diff(
             first, second, tolerance=None, absolute_tolerance=None
         ))
         assert [] == diffed


### PR DESCRIPTION
Hi
I encountered an issue using this nice package: when I want to compare floats, I sometimes need absolute tolerance because of very small values. For example, I don't really care about 100% difference between `1e-16` and `2e-16`, while I do care of a 1% difference between `1` and `1.01`. This case could be solved using a tolerance of `0.01` and an absolute tolerance of `1e-15`.
This PR adds this feature with a few test cases that show more examples.