### PR TITLE
merge: support ignore param to diff function

### DIFF
--- a/dictdiffer/merge.py
+++ b/dictdiffer/merge.py
@@ -37,7 +37,7 @@ class Merger(object):
 
     def __init__(self,
                  lca, first, second, actions,
-                 path_limits=[], additional_info=None):
+                 path_limits=[], additional_info=None, ignore=None):
         """Initialize the Merger object.
 
         :param lca: latest common ancestor of the two diverging data structures
@@ -47,11 +47,13 @@ class Merger(object):
                             dictdiffer.utils.PathLimit object
         :param additional_info: Any object containing additional information
                                 used by the resolution functions
+        :param ignore: Set of keys that should not be merged
         """
         self.lca = lca
         self.first = first
         self.second = second
         self.path_limit = PathLimit(path_limits)
+        self.ignore = ignore
 
         self.actions = actions
         self.additional_info = additional_info
@@ -104,9 +106,11 @@ class Merger(object):
         """
         self.first_patches = list(diff(self.lca, self.first,
                                        path_limit=self.path_limit,
+                                       ignore=self.ignore,
                                        expand=True))
         self.second_patches = list(diff(self.lca, self.second,
                                         path_limit=self.path_limit,
+                                        ignore=self.ignore,
                                         expand=True))
 
     def find_conflicts(self):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -64,6 +64,18 @@ class MergerTest(unittest.TestCase):
             self.assertEqual(patch(m.unified_patches, lca),
                              expected_value)
 
+    def test_run_with_ignore(self):
+        lca = {'changeme': 'Jo', 'ignore': 'Something'}
+        first = {'changeme': 'Joe', 'ignore': 'Nothing'}
+        second = {'changeme': 'Jo', 'ignore': ''}
+
+        m = Merger(lca, first, second, {}, ignore={'ignore'})
+
+        try:
+            m.run()
+        except UnresolvedConflictsException:
+            self.fail('UnresolvedConflictsException should not be raised')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
My use-case requires the `ignore` param when diffing dictionaries.

I started using `Merger` today, and found this option was missing in that class.