### PR TITLE
action selection flag when patching

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -275,7 +275,7 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     return _diff_recursive(first, second, node)
 
 
-def patch(diff_result, destination, in_place=False):
+def patch(diff_result, destination, in_place=False, action_flags="arc"):
     """Patch the diff result to the destination dictionary.
 
     :param diff_result: Changes returned by ``diff``.
@@ -325,7 +325,8 @@ def patch(diff_result, destination, in_place=False):
     }
 
     for action, node, changes in diff_result:
-        patchers[action](node, changes)
+        if action[0] in action_flags:
+            patchers[action](node, changes)
 
     return destination
 

--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -285,6 +285,10 @@ def patch(diff_result, destination, in_place=False, action_flags="arc"):
                      Setting ``in_place=True`` means that patch will apply
                      the changes directly to and return the destination
                      structure.
+    :param action_flags: By default ('arc'), apply all actions: "add", "remove",
+                     "change". Setting ``actions_flag='a'`` means that
+                     pactch will apply only "add" items in the ``diff_result
+                     ``. Similarly, 'ac' only apply "add" and "change".
     """
     if not in_place:
         destination = deepcopy(destination)

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.9.0'
+__version__ = '0.1.dev159+dirty'

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.1.dev159+dirty'
+__version__ = '0.9.0'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,13 @@ Now we can apply the diff result with :func:`.patch` method:
 
     assert patched == second
 
+use `action_flags` parameter to select desired actions:
+'a' for 'add','r' for 'remove', 'c' for 'change' or any other
+combinations.
+
+.. code-block:: python
+
+    patched = patch(result, first, action_flags='a')
 
 Also we can swap the diff result with :func:`.swap` method:
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@
 
 import unittest
 
+from dictdiffer import diff, patch
 from dictdiffer.utils import (PathLimit, WildcardDict, create_dotted_node,
                               dot_lookup, get_path, is_super_path, nested_hash)
 
@@ -144,3 +145,46 @@ class UtilsTest(unittest.TestCase):
         nested_hash((1, 2, 3))
         nested_hash(set([1, 2, 3]))
         nested_hash({'foo': 'bar'})
+
+    def test_limit_actions_patch(self):
+        x = {"a": True, "b": {"b1": True, "b2": False}, "c": {"c1": True}}
+        y = {"a": False, "b": {"b1": True}, "c": {"c1": False, "c2": False}}
+        z_a = {
+            "a": True,
+            "b": {"b1": True, "b2": False},
+            "c": {"c1": True, "c2": False},
+        }  # add only
+        z_r = {"a": True, "b": {"b1": True}, "c": {"c1": True}}  # remove only
+        z_c = {
+            "a": False,
+            "b": {"b1": True, "b2": False},
+            "c": {"c1": False},
+        }  # change only
+        z_ar = {
+            "a": True,
+            "b": {"b1": True},
+            "c": {"c1": True, "c2": False},
+        }  # add and remove
+        z_ac = {
+            "a": False,
+            "b": {"b1": True, "b2": False},
+            "c": {"c1": False, "c2": False},
+        }  # add and change
+        z_rc = {
+            "a": False,
+            "b": {"b1": True},
+            "c": {"c1": False}}  # remove and change
+        z_arc = y  # all actions. Default
+        test_dict = {
+            "a": z_a,
+            "r": z_r,
+            "c": z_c,
+            "ar": z_ar,
+            "ac": z_ac,
+            "rc": z_rc,
+            "arc": z_arc,
+        }
+        for k in test_dict:
+            result = diff(x, y)
+            patched = patch(result, x, action_flags=k)
+            self.assertEqual(patched, test_dict[k])


### PR DESCRIPTION
### Description

Add action selection flag in the `dictdiffer.patch` function to allow selectively patching. For example, set ``action_flags='a'`` would only apply `add` items in the `differ_results`. See examples in the `test_limit_actions_patch` function in [tests/test_utils.py](https://github.com/inveniosoftware/dictdiffer/compare/master...ZeitgeberH:dictdiffer:master?expand=1#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

-  [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
-  [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
