### PR TITLE
Reverse changes if item is removed

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -354,7 +354,7 @@ def swap(diff_result):
         return REMOVE, node, list(reversed(changes))
 
     def remove(node, changes):
-        return ADD, node, changes
+        return ADD, node, list(reversed(changes))
 
     def change(node, changes):
         first, second = changes


### PR DESCRIPTION
To fix https://github.com/inveniosoftware/dictdiffer/issues/178, I think in function `swap` needs to be modified. If a swap is performed on a `remove` action, the list of changes needs to be reversed. Just like it is done in case of an `add` action.

Do you agree? 

I can also add some tests if you want. (I noticed that there are no tests on the revert or swap methods until now)
