### PR TITLE
diff: allow tolerance only between floats

### DIFF
--- a/dictdiffer/__init__.py
+++ b/dictdiffer/__init__.py
@@ -76,8 +76,9 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     ...           path_limit=PathLimit([('a', 'b')])))
     [('add', '', [('a', {})]), ('add', 'a', [('b', 'c')])]
 
-     >>> from dictdiffer.utils import PathLimit
-    >>> list(diff({'a': {'b': 'c'}}, {'a': {'b': 'c'}}, path_limit=PathLimit([('a',)])))
+    >>> from dictdiffer.utils import PathLimit
+    >>> list(diff({'a': {'b': 'c'}}, {'a': {'b': 'c'}},
+    ...           path_limit=PathLimit([('a',)])))
     []
 
     The patch can be expanded to small units e.g. when adding multiple values:
@@ -102,11 +103,14 @@ def diff(first, second, node=None, ignore=None, path_limit=None, expand=False,
     :param path_limit: List of path limit tuples or dictdiffer.utils.Pathlimit
                        object to limit the diff recursion depth.
                        A diff is still performed beyond the path_limit,
-                       but individual differences will be aggregated up to the path_limit.
+                       but individual differences will be aggregated up to the
+                       path_limit.
     :param expand: Expand the patches.
-    :param tolerance: Threshold to consider when comparing two float numbers.
+    :param tolerance: Relative threshold for comparing two floating-point
+                      numbers as equal, expressed as a proportion of the
+                      maximum of the two
     :param absolute_tolerance: Absolute threshold to consider when comparing
-                               two float numbers.
+                               two floating-point numbers.
     :param dot_notation: Boolean to toggle dot notation on and off.
 
     .. versionchanged:: 0.3

--- a/dictdiffer/utils.py
+++ b/dictdiffer/utils.py
@@ -13,7 +13,6 @@ import math
 import sys
 from itertools import zip_longest
 
-num_types = int, float
 EPSILON = sys.float_info.epsilon
 
 
@@ -256,8 +255,8 @@ def dot_lookup(source, lookup, parent=False):
 def are_different(first, second, tolerance, absolute_tolerance=None):
     """Check if 2 values are different.
 
-    In case of numerical values, the tolerance is used to check if the values
-    are different.
+    In case of 2 floating-point values, the tolerance is used to check if the
+    values are different.
     In all other cases, the difference is straight forward.
     """
     if first == second:
@@ -269,8 +268,8 @@ def are_different(first, second, tolerance, absolute_tolerance=None):
     if first_is_nan or second_is_nan:
         # two 'NaN' values are not different (see issue #114)
         return not (first_is_nan and second_is_nan)
-    elif isinstance(first, num_types) and isinstance(second, num_types):
-        # two numerical values are compared with tolerance
+    elif isinstance(first, float) and isinstance(second, float):
+        # two floating-precision values are compared with tolerance
         return not math.isclose(
             first,
             second,

--- a/dictdiffer/version.py
+++ b/dictdiffer/version.py
@@ -3,4 +3,4 @@
 # setup.py and docs/conf.py
 """Version information for dictdiffer package."""
 
-__version__ = '0.9.0'
+__version__ = '0.1.dev160'


### PR DESCRIPTION
### Description

For https://github.com/inveniosoftware/dictdiffer/issues/181

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://github.com/inveniosoftware/dictdiffer/issues/181).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
