### PR TITLE
Only install pytest-runner if required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -54,9 +55,11 @@ for key, reqs in extras_require.items():
     extras_require['all'].extend(reqs)
 
 setup_requires = [
-    'pytest-runner>=2.7',
     'setuptools_scm>=3.1.0',
 ]
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+if needs_pytest:
+    setup_requires.append('pytest-runner>=2.7')
 
 packages = find_packages()
 


### PR DESCRIPTION
By making this requirement conditional we can avoid installing it unless it is actually being used.

See:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#conditional-requirement
