### PR TITLE
tests: remove pytest-runner / setup.py test support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ for key, reqs in extras_require.items():
     extras_require['all'].extend(reqs)
 
 setup_requires = [
-    'pytest-runner>=2.7',
     'setuptools_scm>=3.1.0',
 ]
 
@@ -93,7 +92,6 @@ setup(
     python_requires='>=3.5',
     extras_require=extras_require,
     setup_requires=setup_requires,
-    tests_require=tests_require,
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,9 @@ envlist = py35, py36, py37, py38, py39
 
 [testenv]
 extras = numpy, tests
+deps = pytest
 commands =
     {envpython} -m check_manifest --ignore ".*-requirements.txt"
     {envpython} -m sphinx.cmd.build -qnNW docs docs/_build/html
-    {envpython} setup.py test
+    {envpython} -m pytest {posargs}
     {envpython} -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Removes `pytest-runner` from `setup_requires`, and remove `test_requires`, which is deprecated and only useful with `setup.py test`.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

This does not affect running the tests with `pytest` or (since the PR updates `tox.ini`) with `tox`.

This would supersede https://github.com/inveniosoftware/dictdiffer/pull/184.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases. **N/A, this affects launching the tests**
- [x] I've added relevant documentation. **N/A, using `setup.py test` was not documented**
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/). **N/A, no string changes**
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions). **N/A, <15 lines and lacking creative work**
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines. **N/A**
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines. **N/A**
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines. **N/A**


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
