### PR TITLE
docs: show how to ignore wildcard paths

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,46 @@ dictionaries using :func:`.diff` method:
         ('add', 'stargazers', [(2, '/users/40')]),
         ('change', 'title', ('hello', 'hellooo'))]
 
+The :func:`.diff` method can ignore fields by passing any container to the
+``ignore`` argument.  This allows custom path matching, for example ignoring a
+field in every object of nested arrays regardless of the array index:
+
+.. code-block:: python
+
+    class IgnorePath:
+        def __init__(self, *path):
+            self.path = path
+
+        def __contains__(self, path):
+            if not isinstance(path, tuple):
+                path = tuple(path.split("."))
+            return len(path) == len(self.path) and all(
+                expected is None or expected == actual
+                for expected, actual in zip(self.path, path)
+            )
+
+    first = {
+        "races": [{
+            "reportingUnits": [{
+                "apiAccessTime": "2018-06-04T12:00:00Z",
+                "name": "North",
+            }],
+        }],
+    }
+    second = {
+        "races": [{
+            "reportingUnits": [{
+                "apiAccessTime": "2018-06-04T12:05:00Z",
+                "name": "North",
+            }],
+        }],
+    }
+
+    ignore = IgnorePath(
+        "races", None, "reportingUnits", None, "apiAccessTime")
+
+    assert list(diff(first, second, ignore=ignore)) == []
+
 
 Now we can apply the diff result with :func:`.patch` method:
 


### PR DESCRIPTION
## Summary
- Document how to use a custom `ignore` container for wildcard path matching.
- Add an example that ignores `apiAccessTime` inside nested arrays regardless of the item indexes.

Fixes #108

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --oneline HEAD -- docs/index.rst`
- Not run locally